### PR TITLE
[BE] 모든 엔티티에 등록 시간, 수정 시간 정보 추가

### DIFF
--- a/backend/src/main/java/harustudy/backend/BackendApplication.java
+++ b/backend/src/main/java/harustudy/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package harustudy.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/harustudy/backend/entity/BaseTimeEntity.java
+++ b/backend/src/main/java/harustudy/backend/entity/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package harustudy.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/backend/src/main/java/harustudy/backend/entity/Member.java
+++ b/backend/src/main/java/harustudy/backend/entity/Member.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/harustudy/backend/entity/MemberProgress.java
+++ b/backend/src/main/java/harustudy/backend/entity/MemberProgress.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "progress_type")
 @Entity
-public abstract class MemberProgress {
+public abstract class MemberProgress extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/harustudy/backend/entity/MemberRecord.java
+++ b/backend/src/main/java/harustudy/backend/entity/MemberRecord.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "record_type")
 @Entity
-public abstract class MemberRecord {
+public abstract class MemberRecord extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/harustudy/backend/entity/ParticipantCode.java
+++ b/backend/src/main/java/harustudy/backend/entity/ParticipantCode.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class ParticipantCode {
+public class ParticipantCode extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/harustudy/backend/entity/Study.java
+++ b/backend/src/main/java/harustudy/backend/entity/Study.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "study_type")
-public abstract class Study {
+public abstract class Study extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #82 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 모든 엔티티에 등록 시간 정보를 추가한다.
- 모든 엔티티에 수정 시간 정보를 추가한다.

기존에는 각 엔티티에 생성 및 수정 시의 시간 정보가 없었습니다
현재는 시간 관련 정보만 기본으로 등록, 상속관계를 가지는 테이블의 경우 부모 테이블에만 시간 정보가 남도록 구성했습니다.
추후 생성자, 수정자에 대한 정보가 기록된다면 `BaseEntity`를 변경해야 합니다.
