### PR TITLE
[FE] Path alias 설정

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -7,13 +7,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:import/recommended",
-    "plugin:jsx-a11y/recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "airbnb-typescript",
-    "airbnb/hooks",
+    "plugin:import/recommended",
     "prettier"
   ],
   "parser": "@typescript-eslint/parser",
@@ -23,11 +18,77 @@
     },
     "ecmaVersion": 12,
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": "./frontend/tsconfig.json"
   },
   "plugins": ["react", "react-hooks", "import", "jsx-a11y", "@typescript-eslint"],
   "rules": {
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/display-name": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "import/no-unresolved": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal", ["parent", "sibling"], "index", "unknown"],
+        "pathGroups": [
+          {
+            "pattern": "react*,react*/**",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": "@Components/**/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Types/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Hooks/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Pages/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Styles/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Constants/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Contexts/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Assets/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Utils/*",
+            "group": "internal",
+            "position": "after"
+          }
+        ],
+        "newlines-between": "always",
+        "pathGroupsExcludedImportTypes": [],
+        "alphabetize": {
+          "order": "asc"
+        }
+      }
+    ]
   }
 }

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,4 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
+import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -14,5 +16,18 @@ const config: StorybookConfig = {
   docs: {
     autodocs: true,
   },
+
+  webpackFinal: async (config) => {
+    if (config.resolve) {
+      config.resolve.plugins = [
+        ...(config.resolve.plugins || []),
+        new TsconfigPathsPlugin({
+          extensions: config.resolve.extensions,
+        }),
+      ];
+    }
+    return config;
+  },
 };
+
 export default config;

--- a/frontend/__test__/example.test.tsx
+++ b/frontend/__test__/example.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import '@testing-library/jest-dom';
 import App from '../src/App';
 

--- a/frontend/jest.config.json
+++ b/frontend/jest.config.json
@@ -4,5 +4,16 @@
   "transform": {
     "\\.[jt]sx?$": "babel-jest",
     "\\.css$": "jest-transform-css"
+  },
+  "moduleNameMapper": {
+    "^\\@Components/(.*)$": "<rootDir>/src/components/$1",
+    "^\\@Types/(.*)$": "<rootDir>/src/types/$1",
+    "^\\@Hooks/(.*)$": "<rootDir>/src/hooks/$1",
+    "^\\@Pages/(.*)$": "<rootDir>/src/pages/$1",
+    "^\\@Styles/(.*)$": "<rootDir>/src/styles/$1",
+    "^\\@Constants/(.*)$": "<rootDir>/src/constants/$1",
+    "^\\@Contexts/(.*)$": "<rootDir>/src/contexts/$1",
+    "^\\@Assets/(.*)$": "<rootDir>/src/assets/$1",
+    "^\\@Utils/(.*)$": "<rootDir>/src/utils/$1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "prettier": "^2.8.8",
     "storybook": "^7.0.25",
     "ts-loader": "^9.4.4",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.1.6",
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import { Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import GlobalStyles from './styles/globalStyle';
-import { lightTheme } from './styles/theme';
-import Button from './components/common/Button/Button';
-import Typography from './components/common/Typography/Typography';
+
+import Button from '@Components/common/Button/Button';
+import Typography from '@Components/common/Typography/Typography';
+
+import GlobalStyles from '@Styles/globalStyle';
+import { lightTheme } from '@Styles/theme';
 
 const App = () => {
   return (
@@ -11,6 +13,7 @@ const App = () => {
       <GlobalStyles />
       <ThemeProvider theme={lightTheme}>
         <Typography variant="h1">Welcome Haru Study!</Typography>
+        <Button variant="secondary">Button</Button>
         <Outlet />
       </ThemeProvider>
     </>

--- a/frontend/src/components/common/Button/Button.stories.tsx
+++ b/frontend/src/components/common/Button/Button.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import Button from './Button';
 import { css } from 'styled-components';
-import color from '../../../styles/color';
+
+import color from '@Styles/color';
+
+import Button from './Button';
 
 type Story = StoryObj<typeof Button>;
 

--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -1,9 +1,14 @@
-import { CSSProp, RuleSet, css, styled } from 'styled-components';
-import color from '../../../styles/color';
 import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { css, styled } from 'styled-components';
+import type { CSSProp, RuleSet } from 'styled-components';
+
+import { Size } from '@Types/style';
+
+import color from '@Styles/color';
+
+import { SIZE } from '@Constants/style';
+
 import CircularProgress from '../CircularProgress/CircularProgress';
-import { SIZE } from '../../../constants/style';
-import { Size } from '../../../types/style';
 
 type Include<T, U> = T extends U ? T : never;
 
@@ -17,17 +22,17 @@ const SIZE_TYPE: Record<ButtonSizeType, RuleSet<object>> = {
 
   small: css`
     padding: 12px 24px;
-    font-size: ${SIZE['small']};
+    font-size: ${SIZE.small};
   `,
 
   medium: css`
     padding: 16px 32px;
-    font-size: ${SIZE['medium']};
+    font-size: ${SIZE.medium};
   `,
 
   large: css`
     padding: 20px 48px;
-    font-size: ${SIZE['large']};
+    font-size: ${SIZE.large};
   `,
 
   'x-large': css`

--- a/frontend/src/components/common/CircularProgress/CircularProgress.stories.tsx
+++ b/frontend/src/components/common/CircularProgress/CircularProgress.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import CircularProgress from './CircularProgress';
 import { css } from 'styled-components';
-import color from '../../../styles/color';
+
+import color from '@Styles/color';
+
+import CircularProgress from './CircularProgress';
 
 type Story = StoryObj<typeof CircularProgress>;
 

--- a/frontend/src/components/common/CircularProgress/CircularProgress.tsx
+++ b/frontend/src/components/common/CircularProgress/CircularProgress.tsx
@@ -1,7 +1,11 @@
-import { CSSProp, css, styled } from 'styled-components';
-import { Size } from '../../../types/style';
-import { SIZE } from '../../../constants/style';
-import color from '../../../styles/color';
+import { css, styled } from 'styled-components';
+import type { CSSProp } from 'styled-components';
+
+import { Size } from '@Types/style';
+
+import color from '@Styles/color';
+
+import { SIZE } from '@Constants/style';
 
 type Props = {
   size?: Size;

--- a/frontend/src/components/common/Input/Input.stories.tsx
+++ b/frontend/src/components/common/Input/Input.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+
 import Input from './Input';
 
 type Story = StoryObj<typeof Input>;

--- a/frontend/src/components/common/Input/Input.tsx
+++ b/frontend/src/components/common/Input/Input.tsx
@@ -9,11 +9,16 @@ import {
   cloneElement,
   forwardRef,
 } from 'react';
-import { CSSProp, RuleSet, css, styled } from 'styled-components';
-import useId from '../../../hooks/useId';
-import colorStyle from '../../../styles/color';
-import { Size } from '../../../types/style';
-import { SIZE } from '../../../constants/style';
+import { css, styled } from 'styled-components';
+import type { CSSProp, RuleSet } from 'styled-components';
+
+import { Size } from '@Types/style';
+
+import useId from '@Hooks/useId';
+
+import color from '@Styles/color';
+
+import { SIZE } from '@Constants/style';
 
 type Include<T, U> = T extends U ? T : never;
 
@@ -25,15 +30,15 @@ const SIZE_TYPE: Record<LabelSizeType, RuleSet<object>> = {
   `,
 
   small: css`
-    font-size: ${SIZE['small']};
+    font-size: ${SIZE.small};
   `,
 
   medium: css`
-    font-size: ${SIZE['medium']};
+    font-size: ${SIZE.medium};
   `,
 
   large: css`
-    font-size: ${SIZE['large']};
+    font-size: ${SIZE.large};
   `,
 
   'x-large': css`
@@ -66,7 +71,7 @@ const Input = ({
 
   return (
     <Layout {...props}>
-      <StyledLabel htmlFor={id} $labelSize="medium" $style={$style}>
+      <StyledLabel htmlFor={id} $labelSize={$labelSize} $style={$style}>
         {label}
       </StyledLabel>
       {cloneElement(child, { id, ...child.props })}
@@ -99,7 +104,7 @@ const StyledBottomText = styled.p<{ isError?: boolean }>`
   font-weight: 200;
 
   ${({ isError }) => css`
-    color: ${isError ? colorStyle.red[600] : colorStyle.neutral[400]};
+    color: ${isError ? color.red[600] : color.neutral[400]};
   `};
 `;
 
@@ -108,7 +113,7 @@ type TextFieldProps = {
   $style?: CSSProp;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-Input.TextField = forwardRef(({ error, $style, ...props }: TextFieldProps, ref: ForwardedRef<HTMLInputElement>) => {
+Input.TextField = forwardRef(({ $style, ...props }: TextFieldProps, ref: ForwardedRef<HTMLInputElement>) => {
   return <StyledInput ref={ref} $style={$style} {...props} />;
 });
 
@@ -116,14 +121,14 @@ type StyledInputProps = Pick<TextFieldProps, '$style'>;
 
 const StyledInput = styled.input<StyledInputProps>`
   &:disabled {
-    background-color: ${colorStyle.neutral[200]};
+    background-color: ${color.neutral[200]};
   }
 
   width: 100%;
   padding: 20px;
   font-size: 2.4rem;
   border-radius: 7px;
-  border: 1px solid ${colorStyle.neutral[200]};
+  border: 1px solid ${color.neutral[200]};
 
   ${({ $style, theme }) => css`
     background-color: ${theme.background};

--- a/frontend/src/components/common/Typography/Typography.stories.ts
+++ b/frontend/src/components/common/Typography/Typography.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+
 import Typography from './Typography';
 
 type Story = StoryObj<typeof Typography>;

--- a/frontend/src/components/common/Typography/Typography.tsx
+++ b/frontend/src/components/common/Typography/Typography.tsx
@@ -1,7 +1,8 @@
 import { PropsWithChildren } from 'react';
-import { CSSProp, css, styled } from 'styled-components';
+import { css, styled } from 'styled-components';
+import type { CSSProp } from 'styled-components';
 
-import colorStyle from '../../../styles/color';
+import colorStyle from '@Styles/color';
 
 type Props = {
   variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p1' | 'p2';

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,5 @@
-import { RouterProvider } from 'react-router-dom';
 import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
 
 import { worker } from './mocks/worker';
 import router from './router';

--- a/frontend/src/mocks/server.ts
+++ b/frontend/src/mocks/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node';
+
 import { handlers } from './handlers';
 
 export const server = setupServer(...handlers);

--- a/frontend/src/mocks/worker.ts
+++ b/frontend/src/mocks/worker.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw';
+
 import { handlers } from './handlers';
 
 export const worker = setupWorker(...handlers);

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
+
 import App from '../App';
 
 const router = createBrowserRouter([

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+
 import resetStyle from './reset';
 import '../fonts/font.css';
 

--- a/frontend/src/types/style.ts
+++ b/frontend/src/types/style.ts
@@ -1,3 +1,3 @@
-import { SIZE } from '../constants/style';
+import { SIZE } from '@Constants/style';
 
 export type Size = keyof typeof SIZE;

--- a/frontend/src/types/styled-components.d.ts
+++ b/frontend/src/types/styled-components.d.ts
@@ -1,5 +1,4 @@
 import 'styled-components';
-import { Variant } from './style';
 
 declare module 'styled-components' {
   export interface DefaultTheme {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -105,5 +106,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src", "__test__"]
 }

--- a/frontend/tsconfig.paths.json
+++ b/frontend/tsconfig.paths.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@Components/*": ["./components/*"],
+      "@Types/*": ["./types/*"],
+      "@Hooks/*": ["./hooks/*"],
+      "@Pages/*": ["./pages/*"],
+      "@Styles/*": ["./styles/*"],
+      "@Constants/*": ["./constants/*"],
+      "@Contexts/*": ["./contexts/*"],
+      "@Assets/*": ["./assets/*"],
+      "@Utils/*": ["./utils/*"]
+    }
+  }
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -13,6 +13,17 @@ module.exports = () => {
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      alias: {
+        '@Components': path.resolve(__dirname, 'src/components'),
+        '@Types': path.resolve(__dirname, 'src/types'),
+        '@Hooks': path.resolve(__dirname, 'src/hooks'),
+        '@Pages': path.resolve(__dirname, 'src/pages'),
+        '@Styles': path.resolve(__dirname, 'src/styles'),
+        '@Constants': path.resolve(__dirname, 'src/constants'),
+        '@Contexts': path.resolve(__dirname, 'src/contexts'),
+        '@Assets': path.resolve(__dirname, 'src/assets'),
+        '@Utils': path.resolve(__dirname, 'src/utils'),
+      },
     },
     devServer: {
       port: 3000,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3262,10 +3262,18 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@^29.5.2":
+"@types/jest@*":
   version "29.5.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.2.tgz#86b4afc86e3a8f3005b297ed8a72494f89e6395b"
   integrity sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
+"@types/jest@^29.5.2":
+  version "29.5.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.3.tgz#7a35dc0044ffb8b56325c6802a4781a626b05777"
+  integrity sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -5310,7 +5318,7 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.5"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.15.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.15.0, enhanced-resolve@^5.7.0:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
   integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
@@ -10020,6 +10028,15 @@ ts-loader@^9.4.4:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
+tsconfig-paths-webpack-plugin@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz#3c6892c5e7319c146eee1e7302ed9e6f2be4f763"
+  integrity sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^4.1.2"
+
 tsconfig-paths@^3.14.1:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
@@ -10027,6 +10044,15 @@ tsconfig-paths@^3.14.1:
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
+tsconfig-paths@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
+  integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
+  dependencies:
+    json5 "^2.2.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 


### PR DESCRIPTION
## 관련 이슈
closed #52

## 구현 기능 및 변경 사항
1. eslint의 parserOptions의 project값을 수정했습니다.
    ```json
    "project": "./frontend/tsconfig.json"
    ```
2. eslint의 extends을 수정했습니다.
    ```json
      "extends": [
          "eslint:recommended",
          "plugin:react/recommended",
          "plugin:@typescript-eslint/recommended",
          "plugin:import/recommended",
          "prettier"
      ],
    ```
3. eslint의 rules에 `import/order`을 추가했습니다.

## 스크린샷(선택)