### PR TITLE
[FE] Menu Component 구현

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -82,7 +82,7 @@
             "position": "after"
           },
           {
-            "pattern": "@Assets/*",
+            "pattern": "@Assets/**/*",
             "group": "internal",
             "position": "after"
           },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
 import Button from '@Components/common/Button/Button';
+import Menu from '@Components/common/Menu/Menu';
 import Typography from '@Components/common/Typography/Typography';
 
 import GlobalStyles from '@Styles/globalStyle';
@@ -14,6 +15,12 @@ const App = () => {
       <ThemeProvider theme={lightTheme}>
         <Typography variant="h1">Welcome Haru Study!</Typography>
         <Button variant="secondary">Button</Button>
+        <Menu>
+          <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1입니다.</Menu.Item>
+          <Menu.Item onClick={() => alert('아이템2을 클릭했습니다.')}>아이템2</Menu.Item>
+          <Menu.Item onClick={() => alert('아이템3을 클릭했습니다.')}>아이템3</Menu.Item>
+          <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>
+        </Menu>
         <Outlet />
       </ThemeProvider>
     </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,6 @@ import { Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
 import Button from '@Components/common/Button/Button';
-import Menu from '@Components/common/Menu/Menu';
 import Typography from '@Components/common/Typography/Typography';
 
 import GlobalStyles from '@Styles/globalStyle';
@@ -15,12 +14,6 @@ const App = () => {
       <ThemeProvider theme={lightTheme}>
         <Typography variant="h1">Welcome Haru Study!</Typography>
         <Button variant="secondary">Button</Button>
-        <Menu>
-          <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1입니다.</Menu.Item>
-          <Menu.Item onClick={() => alert('아이템2을 클릭했습니다.')}>아이템2</Menu.Item>
-          <Menu.Item onClick={() => alert('아이템3을 클릭했습니다.')}>아이템3</Menu.Item>
-          <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>
-        </Menu>
         <Outlet />
       </ThemeProvider>
     </>

--- a/frontend/src/assets/icons/HamburgerIcon.tsx
+++ b/frontend/src/assets/icons/HamburgerIcon.tsx
@@ -1,0 +1,11 @@
+const HamburgerIcon = () => {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <g id="material-symbols:menu">
+        <path id="Vector" d="M3 18V16H21V18H3ZM3 13V11H21V13H3ZM3 8V6H21V8H3Z" fill="black" />
+      </g>
+    </svg>
+  );
+};
+
+export default HamburgerIcon;

--- a/frontend/src/components/common/Menu/Menu.stories.tsx
+++ b/frontend/src/components/common/Menu/Menu.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { css } from 'styled-components';
 
 import Menu from './Menu';
 
@@ -27,5 +28,25 @@ export const DefaultMenu: Story = {
         <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>
       </>
     ),
+  },
+};
+
+/**
+ * `RightMenu`는 오른쪽 정렬된 `Menu` 스토리입니다.
+ */
+export const RightMenu: Story = {
+  args: {
+    children: (
+      <>
+        <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템2을 클릭했습니다.')}>아이템2</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템3을 클릭했습니다.')}>아이템3</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>
+      </>
+    ),
+    menuListPosition: 'left',
+    $style: css`
+      margin: 0 0 0 auto;
+    `,
   },
 };

--- a/frontend/src/components/common/Menu/Menu.stories.tsx
+++ b/frontend/src/components/common/Menu/Menu.stories.tsx
@@ -21,7 +21,7 @@ export const DefaultMenu: Story = {
   args: {
     children: (
       <>
-        <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1입니다.</Menu.Item>
         <Menu.Item onClick={() => alert('아이템2을 클릭했습니다.')}>아이템2</Menu.Item>
         <Menu.Item onClick={() => alert('아이템3을 클릭했습니다.')}>아이템3</Menu.Item>
         <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>

--- a/frontend/src/components/common/Menu/Menu.stories.tsx
+++ b/frontend/src/components/common/Menu/Menu.stories.tsx
@@ -21,7 +21,7 @@ export const DefaultMenu: Story = {
   args: {
     children: (
       <>
-        <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1입니다.</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1</Menu.Item>
         <Menu.Item onClick={() => alert('아이템2을 클릭했습니다.')}>아이템2</Menu.Item>
         <Menu.Item onClick={() => alert('아이템3을 클릭했습니다.')}>아이템3</Menu.Item>
         <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>

--- a/frontend/src/components/common/Menu/Menu.stories.tsx
+++ b/frontend/src/components/common/Menu/Menu.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Menu from './Menu';
+
+type Story = StoryObj<typeof Menu>;
+
+/**
+ * `Menu` 컴포넌트는 여러 목록을 보여주고 특정 이벤트를 위한 컴포넌트입니다.
+ */
+const meta: Meta<typeof Menu> = {
+  title: 'NAVIGATION/Menu',
+  component: Menu,
+};
+
+export default meta;
+
+/**
+ * `DefaultMenu`는 메뉴의 기본 `Menu` 스토리입니다.
+ */
+export const DefaultMenu: Story = {
+  args: {
+    children: (
+      <>
+        <Menu.Item onClick={() => alert('아이템1을 클릭했습니다.')}>아이템1</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템2을 클릭했습니다.')}>아이템2</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템3을 클릭했습니다.')}>아이템3</Menu.Item>
+        <Menu.Item onClick={() => alert('아이템4을 클릭했습니다.')}>아이템4</Menu.Item>
+      </>
+    ),
+  },
+};

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,5 +1,6 @@
-import { Children, LiHTMLAttributes, PropsWithChildren, ReactElement, cloneElement, useState } from 'react';
-import { styled } from 'styled-components';
+import { Children, PropsWithChildren, ReactElement, cloneElement, useState } from 'react';
+import { css, styled } from 'styled-components';
+import type { CSSProp } from 'styled-components';
 
 import useOutsideClick from '@Hooks/useOutsideClick';
 
@@ -7,7 +8,25 @@ import color from '@Styles/color';
 
 import HamburgerIcon from '@Assets/icons/HamburgerIcon';
 
-const Menu = ({ children }: PropsWithChildren) => {
+import MenuItem from './MenuItem';
+
+const MENU_LIST_POSITION = {
+  left: css`
+    right: 0;
+    text-align: end;
+  `,
+  right: css`
+    left: 0;
+    text-align: start;
+  `,
+} as const;
+
+type Props = {
+  $style: CSSProp;
+  menuListPosition?: keyof typeof MENU_LIST_POSITION;
+};
+
+const Menu = ({ menuListPosition = 'right', $style, children }: PropsWithChildren<Props>) => {
   const [isOpenMenu, setIsOpenMenu] = useState(false);
 
   const ref = useOutsideClick<HTMLDivElement>(() => setIsOpenMenu(false));
@@ -17,12 +36,12 @@ const Menu = ({ children }: PropsWithChildren) => {
   const closeMenu = () => setIsOpenMenu(false);
 
   return (
-    <MenuLayout ref={ref}>
+    <MenuLayout ref={ref} $style={$style}>
       <MenuIconWrapper onClick={toggleMenu}>
         <HamburgerIcon />
       </MenuIconWrapper>
       {isOpenMenu && (
-        <MenuList>
+        <MenuList menuListPosition={menuListPosition}>
           {Children.map(children, (child) => {
             const item = child as ReactElement;
             return cloneElement(item, { closeMenu });
@@ -35,7 +54,11 @@ const Menu = ({ children }: PropsWithChildren) => {
 
 export default Menu;
 
-const MenuLayout = styled.div`
+Menu.Item = MenuItem;
+
+type MenuLayoutProp = Pick<Props, '$style'>;
+
+const MenuLayout = styled.div<MenuLayoutProp>`
   position: relative;
 
   width: fit-content;
@@ -43,13 +66,28 @@ const MenuLayout = styled.div`
   svg {
     cursor: pointer;
   }
+
+  ${({ $style }) => css`
+    ${$style}
+  `}
 `;
 
-const MenuIconWrapper = styled.div``;
+const MenuIconWrapper = styled.div`
+  padding: 4px;
+  border-radius: 50%;
 
-const MenuList = styled.ul`
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: ${color.neutral[100]};
+  }
+`;
+
+type MenuListProp = Required<Pick<Props, 'menuListPosition'>>;
+
+const MenuList = styled.ul<MenuListProp>`
   position: absolute;
-  top: 30px;
+  top: 34px;
 
   display: grid;
   row-gap: 6px;
@@ -60,34 +98,8 @@ const MenuList = styled.ul`
   border-radius: 8px;
 
   box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+
+  ${({ menuListPosition }) => css`
+    ${MENU_LIST_POSITION[menuListPosition]}
+  `}
 `;
-
-type MenuItemProps = PropsWithChildren<{ closeMenu?: () => void; onClick: () => void }> &
-  LiHTMLAttributes<HTMLLIElement>;
-
-const MenuItem = ({ children, onClick, closeMenu, ...props }: MenuItemProps) => {
-  const handleClick = () => {
-    if (closeMenu) closeMenu();
-    onClick();
-  };
-
-  return (
-    <MenuItemLayout onClick={handleClick} {...props}>
-      {children}
-    </MenuItemLayout>
-  );
-};
-
-const MenuItemLayout = styled.li`
-  padding: 6px 24px;
-
-  transition: background-color 0.2s ease;
-
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${color.neutral[100]};
-  }
-`;
-
-Menu.Item = MenuItem;

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,6 +1,8 @@
 import { LiHTMLAttributes, PropsWithChildren } from 'react';
 import { styled } from 'styled-components';
 
+import color from '@Styles/color';
+
 import HamburgerIcon from '@Assets/icons/HamburgerIcon';
 
 const Menu = ({ children }: PropsWithChildren) => {
@@ -14,14 +16,43 @@ const Menu = ({ children }: PropsWithChildren) => {
 
 export default Menu;
 
-const MenuLayout = styled.div``;
+const MenuLayout = styled.div`
+  position: relative;
 
-const MenuList = styled.ul``;
+  svg {
+    cursor: pointer;
+  }
+`;
+
+const MenuList = styled.ul`
+  position: absolute;
+  top: 30px;
+
+  display: grid;
+  row-gap: 6px;
+
+  width: fit-content;
+
+  padding: 10px 0px;
+  border-radius: 8px;
+
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+`;
 
 const MenuItem = ({ children, onClick }: PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>) => {
   return <MenuItemLayout onClick={onClick}>{children}</MenuItemLayout>;
 };
 
-const MenuItemLayout = styled.li``;
+const MenuItemLayout = styled.li`
+  padding: 6px 24px;
+
+  transition: background-color 0.2s ease;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${color.neutral[100]};
+  }
+`;
 
 Menu.Item = MenuItem;

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -22,7 +22,7 @@ const MENU_LIST_POSITION = {
 } as const;
 
 type Props = {
-  $style: CSSProp;
+  $style?: CSSProp;
   menuListPosition?: keyof typeof MENU_LIST_POSITION;
 };
 

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,14 +1,7 @@
-import React, {
-  Children,
-  LiHTMLAttributes,
-  PropsWithChildren,
-  ReactElement,
-  cloneElement,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { Children, LiHTMLAttributes, PropsWithChildren, ReactElement, cloneElement, useState } from 'react';
 import { styled } from 'styled-components';
+
+import useOutsideClick from '@Hooks/useOutsideClick';
 
 import color from '@Styles/color';
 
@@ -16,24 +9,12 @@ import HamburgerIcon from '@Assets/icons/HamburgerIcon';
 
 const Menu = ({ children }: PropsWithChildren) => {
   const [isOpenMenu, setIsOpenMenu] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+
+  const ref = useOutsideClick<HTMLDivElement>(() => setIsOpenMenu(false));
 
   const toggleMenu = () => setIsOpenMenu((prev) => !prev);
 
   const closeMenu = () => setIsOpenMenu(false);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        closeMenu();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [ref]);
 
   return (
     <MenuLayout ref={ref}>

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,0 +1,27 @@
+import { LiHTMLAttributes, PropsWithChildren } from 'react';
+import { styled } from 'styled-components';
+
+import HamburgerIcon from '@Assets/icons/HamburgerIcon';
+
+const Menu = ({ children }: PropsWithChildren) => {
+  return (
+    <MenuLayout>
+      <HamburgerIcon />
+      <MenuList>{children}</MenuList>
+    </MenuLayout>
+  );
+};
+
+export default Menu;
+
+const MenuLayout = styled.div``;
+
+const MenuList = styled.ul``;
+
+const MenuItem = ({ children, onClick }: PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>) => {
+  return <MenuItemLayout onClick={onClick}>{children}</MenuItemLayout>;
+};
+
+const MenuItemLayout = styled.li``;
+
+Menu.Item = MenuItem;

--- a/frontend/src/components/common/Menu/Menu.tsx
+++ b/frontend/src/components/common/Menu/Menu.tsx
@@ -1,4 +1,13 @@
-import { LiHTMLAttributes, PropsWithChildren } from 'react';
+import React, {
+  Children,
+  LiHTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+  cloneElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { styled } from 'styled-components';
 
 import color from '@Styles/color';
@@ -6,10 +15,39 @@ import color from '@Styles/color';
 import HamburgerIcon from '@Assets/icons/HamburgerIcon';
 
 const Menu = ({ children }: PropsWithChildren) => {
+  const [isOpenMenu, setIsOpenMenu] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const toggleMenu = () => setIsOpenMenu((prev) => !prev);
+
+  const closeMenu = () => setIsOpenMenu(false);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        closeMenu();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref]);
+
   return (
-    <MenuLayout>
-      <HamburgerIcon />
-      <MenuList>{children}</MenuList>
+    <MenuLayout ref={ref}>
+      <MenuIconWrapper onClick={toggleMenu}>
+        <HamburgerIcon />
+      </MenuIconWrapper>
+      {isOpenMenu && (
+        <MenuList>
+          {Children.map(children, (child) => {
+            const item = child as ReactElement;
+            return cloneElement(item, { closeMenu });
+          })}
+        </MenuList>
+      )}
     </MenuLayout>
   );
 };
@@ -19,10 +57,14 @@ export default Menu;
 const MenuLayout = styled.div`
   position: relative;
 
+  width: fit-content;
+
   svg {
     cursor: pointer;
   }
 `;
+
+const MenuIconWrapper = styled.div``;
 
 const MenuList = styled.ul`
   position: absolute;
@@ -31,7 +73,7 @@ const MenuList = styled.ul`
   display: grid;
   row-gap: 6px;
 
-  width: fit-content;
+  width: max-content;
 
   padding: 10px 0px;
   border-radius: 8px;
@@ -39,8 +81,20 @@ const MenuList = styled.ul`
   box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
 `;
 
-const MenuItem = ({ children, onClick }: PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>) => {
-  return <MenuItemLayout onClick={onClick}>{children}</MenuItemLayout>;
+type MenuItemProps = PropsWithChildren<{ closeMenu?: () => void; onClick: () => void }> &
+  LiHTMLAttributes<HTMLLIElement>;
+
+const MenuItem = ({ children, onClick, closeMenu, ...props }: MenuItemProps) => {
+  const handleClick = () => {
+    if (closeMenu) closeMenu();
+    onClick();
+  };
+
+  return (
+    <MenuItemLayout onClick={handleClick} {...props}>
+      {children}
+    </MenuItemLayout>
+  );
 };
 
 const MenuItemLayout = styled.li`

--- a/frontend/src/components/common/Menu/MenuItem.tsx
+++ b/frontend/src/components/common/Menu/MenuItem.tsx
@@ -1,0 +1,41 @@
+import { LiHTMLAttributes, PropsWithChildren } from 'react';
+import { styled } from 'styled-components';
+
+import color from '@Styles/color';
+
+type Props = {
+  closeMenu?: () => void;
+  onClick: () => void;
+};
+
+const MenuItem = ({
+  children,
+  onClick,
+  closeMenu,
+  ...props
+}: PropsWithChildren<Props> & LiHTMLAttributes<HTMLLIElement>) => {
+  const handleClick = () => {
+    if (closeMenu) closeMenu();
+    onClick();
+  };
+
+  return (
+    <MenuItemLayout onClick={handleClick} {...props}>
+      {children}
+    </MenuItemLayout>
+  );
+};
+
+export default MenuItem;
+
+const MenuItemLayout = styled.li`
+  padding: 6px 24px;
+
+  transition: background-color 0.2s ease;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${color.neutral[100]};
+  }
+`;

--- a/frontend/src/hooks/useOutsideClick.ts
+++ b/frontend/src/hooks/useOutsideClick.ts
@@ -10,10 +10,10 @@ const useOutsideClick = <T extends HTMLElement>(onClickOutside: () => void) => {
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('click', handleClickOutside);
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     };
   }, [onClickOutside, ref]);
 

--- a/frontend/src/hooks/useOutsideClick.ts
+++ b/frontend/src/hooks/useOutsideClick.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+const useOutsideClick = <T extends HTMLElement>(onClickOutside: () => void) => {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onClickOutside, ref]);
+
+  return ref;
+};
+
+export default useOutsideClick;

--- a/frontend/src/styles/reset.ts
+++ b/frontend/src/styles/reset.ts
@@ -54,6 +54,13 @@ const resetStyle = css`
     border-collapse: collapse;
     border-spacing: 0;
   }
+
+  ol,
+  ul {
+    list-style: none;
+    margin: 0px;
+    padding: 0px;
+  }
 `;
 
 export default resetStyle;


### PR DESCRIPTION
## 관련 이슈
closed #45  

## 구현 기능 및 변경 사항

- Menu Component 구현
- useOutsideClick 훅 구현(참고 - https://gurtn.tistory.com/203)

```tsx
const App () => {
    const ref = useOutsideClick<HTMLDivElement>(() => someFunction());

    // ...
}
```

- 기존 `useRef` 사용법과 같지만 `ref`로 지정한 영역을 제외한 영역을 클릭했을 때 발생하게 되는 함수를 인자로 넘깁니다.

## 스크린샷(선택)

<img width="271" alt="스크린샷 2023-07-19 오후 1 39 40" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/edbac84f-cd31-410f-950c-e728ee47a455">
<img width="396" alt="스크린샷 2023-07-19 오후 1 39 35" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/c3368884-5671-47a1-bf9f-1fd2a43725c4">

