### PR TITLE
[BE] 스터디 참여시 MemberProgress 영속화 되지 않는 문제 수정

### DIFF
--- a/backend/src/main/java/harustudy/backend/entity/Study.java
+++ b/backend/src/main/java/harustudy/backend/entity/Study.java
@@ -2,6 +2,7 @@ package harustudy.backend.entity;
 
 import harustudy.backend.exception.DuplicatedNicknameException;
 import harustudy.backend.exception.StudyNameLengthException;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
@@ -39,7 +40,7 @@ public abstract class Study extends BaseTimeEntity {
     @Column(length = 10)
     private String name;
 
-    @OneToMany(mappedBy = "study")
+    @OneToMany(mappedBy = "study", cascade = CascadeType.PERSIST)
     private List<MemberProgress> memberProgresses = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -59,19 +60,17 @@ public abstract class Study extends BaseTimeEntity {
     }
 
     public boolean isParticipatedMember(Member member) {
-        return memberProgresses.stream()
-                .anyMatch(memberProgress -> memberProgress.isOwnedBy(member));
+        return memberProgresses.stream().anyMatch(memberProgress -> memberProgress.isOwnedBy(member));
     }
 
     public void participate(Member member) {
         validateDuplicatedNickname(member);
-        PomodoroProgress pomodoroProgress = new PomodoroProgress(this, member);
+        MemberProgress pomodoroProgress = new PomodoroProgress(this, member);
         memberProgresses.add(pomodoroProgress);
     }
 
     private void validateDuplicatedNickname(Member member) {
-        if (memberProgresses.stream()
-                .anyMatch(memberProgress -> memberProgress.hasSameNicknameMember(member))) {
+        if (memberProgresses.stream().anyMatch(memberProgress -> memberProgress.hasSameNicknameMember(member))) {
             throw new DuplicatedNicknameException();
         }
     }

--- a/backend/src/test/java/harustudy/backend/service/ParticipateServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/service/ParticipateServiceTest.java
@@ -8,6 +8,7 @@ import harustudy.backend.entity.Study;
 import harustudy.backend.exception.DuplicatedNicknameException;
 import harustudy.backend.repository.MemberRepository;
 import harustudy.backend.repository.StudyRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ class ParticipateServiceTest {
     @Autowired
     private StudyRepository studyRepository;
 
+    @Autowired
+    private EntityManager entityManager;
 
     @Test
     void 닉네임을_받아_신규_멤버를_생성하고_스터디에_등록한다() {
@@ -40,6 +43,9 @@ class ParticipateServiceTest {
         // when
         Long participatedMemberId = participateService.participate(existedStudyId,
                 newMemberNickname);
+
+        entityManager.flush();
+        entityManager.clear();
 
         // then
         Member member = memberRepository.findById(participatedMemberId).get();


### PR DESCRIPTION
## 관련 이슈

- closed #115 

## 구현 기능 및 변경 사항

- Study 저장시 MemberProgress를 Study.add 했으나 MemberProgress가 영속화 되지 않아서 Study.MemberProgresses에 cascade.Persist 적용했습니다. Cascade를 걸지 말고 서비스에서 로직을 수행하자는 의견이 있었으나 닉네임 중복 검증 로직도 다 서비스로 빼지 않으면 에러가 발생해서 일단 cascade를 적용하는 방향으로 해결했습니다.
