### PR TITLE
[BE] 젠킨스 무한 출력 스트림 리다이렉션

### DIFF
--- a/jenkins/backend-prod.jenkinsfile
+++ b/jenkins/backend-prod.jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         stage('publish on ssh') {
             steps {
                 dir('backend') {
-                    sshPublisher(publishers: [sshPublisherDesc(configName: 'haru-study-prod', transfers: [sshTransfer(cleanRemote: false, excludes: '', execCommand: 'sh /home/ubuntu/2023-haru-study/script/backend_deploy.sh', execTimeout: 120000, flatten: false, makeEmptyDirs: false, noDefaultExcludes: false, patternSeparator: '[, ]+', remoteDirectory: '/2023-haru-study/deploy', remoteDirectorySDF: false, removePrefix: 'build/libs', sourceFiles: 'build/libs/*.jar')], usePromotionTimestamp: false, useWorkspaceInPromotion: false, verbose: true)])
+                    sshPublisher(publishers: [sshPublisherDesc(configName: 'haru-study-prod', transfers: [sshTransfer(cleanRemote: false, excludes: '', execCommand: 'sh /home/ubuntu/2023-haru-study/script/backend_deploy.sh > backend_deploy.out 2>&1', execTimeout: 120000, flatten: false, makeEmptyDirs: false, noDefaultExcludes: false, patternSeparator: '[, ]+', remoteDirectory: '/2023-haru-study/deploy', remoteDirectorySDF: false, removePrefix: 'build/libs', sourceFiles: 'build/libs/*.jar')], usePromotionTimestamp: false, useWorkspaceInPromotion: false, verbose: true)])
                 }
             }
         }


### PR DESCRIPTION
## 관련 이슈

- closed #117 

## 구현 기능 및 변경 사항

-  ssh publisher로 원격 스크립트를 실행하면 stdoutput이 닫히거나 timeout이 발생할 때까지 스크립트가 닫히지 않음. 그래서 script로 백그라운드 작업을 하면 모든 output을 redirect 해서 스크립트가 종료되도록 수정.