### PR TITLE
[BE] 현재 사이클 조회 응답 수정

### DIFF
--- a/backend/src/main/java/harustudy/backend/config/OpenApiConfiguration.java
+++ b/backend/src/main/java/harustudy/backend/config/OpenApiConfiguration.java
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/backend/src/main/java/harustudy/backend/content/controller/ContentController.java
+++ b/backend/src/main/java/harustudy/backend/content/controller/ContentController.java
@@ -1,6 +1,5 @@
 package harustudy.backend.content.controller;
 
-import harustudy.backend.content.dto.CurrentCyclePlanResponse;
 import harustudy.backend.content.dto.MemberContentResponses;
 import harustudy.backend.content.service.ContentService;
 import jakarta.validation.constraints.NotNull;
@@ -43,7 +42,7 @@ public class ContentController {
     }
 
     @GetMapping("/api/studies/{studyId}/members/{memberId}/content/plans")
-    public ResponseEntity<CurrentCyclePlanResponse> findCurrentCyclePlan(
+    public ResponseEntity<Map<String, String>> findCurrentCyclePlan(
             @PathVariable Long studyId,
             @PathVariable Long memberId,
             @RequestParam @NotNull Integer cycle

--- a/backend/src/main/java/harustudy/backend/content/dto/CurrentCyclePlanResponse.java
+++ b/backend/src/main/java/harustudy/backend/content/dto/CurrentCyclePlanResponse.java
@@ -1,7 +1,0 @@
-package harustudy.backend.content.dto;
-
-import java.util.Map;
-
-public record CurrentCyclePlanResponse(Map<String, String> plan) {
-
-}

--- a/backend/src/main/java/harustudy/backend/content/service/ContentService.java
+++ b/backend/src/main/java/harustudy/backend/content/service/ContentService.java
@@ -5,7 +5,6 @@ import harustudy.backend.common.EntityNotFoundException.PomodoroProgressNotFound
 import harustudy.backend.common.EntityNotFoundException.PomodoroRecordNotFound;
 import harustudy.backend.common.EntityNotFoundException.StudyNotFound;
 import harustudy.backend.content.domain.PomodoroContent;
-import harustudy.backend.content.dto.CurrentCyclePlanResponse;
 import harustudy.backend.content.dto.MemberContentResponse;
 import harustudy.backend.content.dto.MemberContentResponses;
 import harustudy.backend.content.repository.ContentRepository;
@@ -33,7 +32,7 @@ public class ContentService {
     private final MemberProgressRepository<PomodoroProgress> memberProgressRepository;
     private final ContentRepository<PomodoroContent> contentRepository;
 
-    public CurrentCyclePlanResponse findCurrentCyclePlan(Long studyId, Long memberId,
+    public Map<String, String> findCurrentCyclePlan(Long studyId, Long memberId,
             Integer cycle) {
         Room room = roomRepository.findById(studyId).orElseThrow(IllegalArgumentException::new);
         Member member = memberRepository.findById(memberId)
@@ -43,8 +42,7 @@ public class ContentService {
                         room, member)
                 .orElseThrow(IllegalArgumentException::new);
 
-        return new CurrentCyclePlanResponse(
-                pomodoroProgress.findPomodoroRecordByCycle(cycle).getPlan());
+        return pomodoroProgress.findPomodoroRecordByCycle(cycle).getPlan();
     }
 
     public void writePlan(Long studyId, Long memberId, Map<String, String> plan) {

--- a/backend/src/test/java/harustudy/backend/integration/FindRoomIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/FindRoomIntegrationTest.java
@@ -6,14 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import harustudy.backend.content.dto.CurrentCyclePlanResponse;
 import harustudy.backend.content.dto.MemberContentResponse;
 import harustudy.backend.content.dto.MemberContentResponses;
 import harustudy.backend.progress.dto.RoomAndProgressStepResponse;
 import harustudy.backend.room.dto.MemberDto;
 import harustudy.backend.room.dto.RoomAndMembersResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -105,19 +107,18 @@ public class FindRoomIntegrationTest extends IntegrationTest {
 
         // then
         String jsonResponse = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
-        CurrentCyclePlanResponse response = objectMapper.readValue(jsonResponse,
-                CurrentCyclePlanResponse.class);
+        Map<String, String> response = objectMapper.readValue(jsonResponse, new TypeReference<>() {});
 
         // then
         assertAll(
-                () -> Assertions.assertThat(response.plan().get("toDo")).isEqualTo("쿠키와 세션"),
-                () -> Assertions.assertThat(response.plan().get("completionCondition")).isEqualTo(
+                () -> Assertions.assertThat(response.get("toDo")).isEqualTo("쿠키와 세션"),
+                () -> Assertions.assertThat(response.get("completionCondition")).isEqualTo(
                         "완료조건"),
-                () -> Assertions.assertThat(response.plan().get("expectedProbability")).isEqualTo(
+                () -> Assertions.assertThat(response.get("expectedProbability")).isEqualTo(
                         "80%"),
-                () -> Assertions.assertThat(response.plan().get("expectedDifficulty")).isEqualTo(
+                () -> Assertions.assertThat(response.get("expectedDifficulty")).isEqualTo(
                         "예상되는 어려움"),
-                () -> Assertions.assertThat(response.plan().get("whatCanYouDo")).isEqualTo(
+                () -> Assertions.assertThat(response.get("whatCanYouDo")).isEqualTo(
                         "가능성을 높이기 위해 무엇을 할 수 있을지?")
         );
     }

--- a/backend/src/test/java/harustudy/backend/progress/service/ProgressServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/progress/service/ProgressServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import harustudy.backend.content.domain.PomodoroContent;
-import harustudy.backend.content.dto.CurrentCyclePlanResponse;
 import harustudy.backend.content.service.ContentService;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.participantcode.domain.CodeGenerationStrategy;
@@ -86,19 +85,19 @@ class ProgressServiceTest {
     @Test
     void 특정_멤버의_현재_사이클의_계획을_조회한다() {
         // given, when
-        CurrentCyclePlanResponse currentCyclePlan = contentService.findCurrentCyclePlan(
+        Map<String, String> currentCyclePlan = contentService.findCurrentCyclePlan(
                 room.getId(), member.getId(), 1);
 
         // then
         assertAll(
-                () -> assertThat(currentCyclePlan.plan().get("toDo")).isEqualTo("쿠키와 세션"),
-                () -> assertThat(currentCyclePlan.plan().get("completionCondition")).isEqualTo(
+                () -> assertThat(currentCyclePlan.get("toDo")).isEqualTo("쿠키와 세션"),
+                () -> assertThat(currentCyclePlan.get("completionCondition")).isEqualTo(
                         "완료조건"),
-                () -> assertThat(currentCyclePlan.plan().get("expectedProbability")).isEqualTo(
+                () -> assertThat(currentCyclePlan.get("expectedProbability")).isEqualTo(
                         "80%"),
-                () -> assertThat(currentCyclePlan.plan().get("expectedDifficulty")).isEqualTo(
+                () -> assertThat(currentCyclePlan.get("expectedDifficulty")).isEqualTo(
                         "예상되는 어려움"),
-                () -> assertThat(currentCyclePlan.plan().get("whatCanYouDo")).isEqualTo(
+                () -> assertThat(currentCyclePlan.get("whatCanYouDo")).isEqualTo(
                         "가능성을 높이기 위해 무엇을 할 수 있을지?")
         );
     }


### PR DESCRIPTION
## 관련 이슈

- closed: #167 

## 구현 기능 및 변경 사항

- api 문서에 현재 사이클 조회 응답 형태가 아래 사진에서 "plan"이 빠져있어 DTO가 아닌 Map<String, String>을 응답하도록 수정했습니다. 


![image](https://github.com/woowacourse-teams/2023-haru-study/assets/35948985/445def7a-382d-4746-8454-0d7371b09f0f)
