### PR TITLE
[BE] 같은 스터디의 재참여 불가 문제

### DIFF
--- a/backend/src/main/java/harustudy/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/harustudy/backend/member/controller/MemberController.java
@@ -1,16 +1,23 @@
 package harustudy.backend.member.controller;
 
 import harustudy.backend.member.dto.NicknameResponse;
+import harustudy.backend.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 public class MemberController {
 
-    @GetMapping("/api/v2/studies/{studyId}/members/{memberId}")
-    public ResponseEntity<NicknameResponse> findNicknameByMemberIdV2(@PathVariable Long memberId) {
-        return ResponseEntity.ok(null);
+    private final MemberService memberService;
+
+    // TODO: studyId는 API 일관성을 위해 보류(현재는 사용하지 않음)
+    @GetMapping("/api/studies/{studyId}/members/{memberId}")
+    public ResponseEntity<NicknameResponse> findNicknameByMemberId(@PathVariable Long memberId) {
+        NicknameResponse response = memberService.findNicknameByMemberId(memberId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/harustudy/backend/member/service/MemberService.java
+++ b/backend/src/main/java/harustudy/backend/member/service/MemberService.java
@@ -1,0 +1,23 @@
+package harustudy.backend.member.service;
+
+import harustudy.backend.common.EntityNotFoundException.MemberNotFound;
+import harustudy.backend.member.domain.Member;
+import harustudy.backend.member.dto.NicknameResponse;
+import harustudy.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public NicknameResponse findNicknameByMemberId(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFound::new);
+        return new NicknameResponse(member.getNickname());
+    }
+}

--- a/backend/src/main/java/harustudy/backend/participantcode/controller/ParticipantCodeController.java
+++ b/backend/src/main/java/harustudy/backend/participantcode/controller/ParticipantCodeController.java
@@ -1,12 +1,9 @@
 package harustudy.backend.participantcode.controller;
 
-import harustudy.backend.participantcode.dto.FindRoomAndNicknameRequest;
-import harustudy.backend.participantcode.dto.FindRoomAndNicknameResponse;
 import harustudy.backend.participantcode.dto.FindRoomRequest;
 import harustudy.backend.participantcode.dto.FindRoomResponse;
 import harustudy.backend.participantcode.service.ParticipantCodeService;
 import jakarta.validation.Valid;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,22 +17,7 @@ public class ParticipantCodeController {
     private final ParticipantCodeService participantCodeService;
 
     @PostMapping("/api/studies/authenticate")
-    public ResponseEntity<FindRoomAndNicknameResponse> checkAuth(
-            @RequestBody FindRoomAndNicknameRequest request
-    ) {
-        if (Objects.isNull(request.memberId())) {
-            return ResponseEntity.ok(
-                    participantCodeService.findRoomByCode(request.participantCode()));
-        }
-        return ResponseEntity.ok(
-                participantCodeService.findRoomByCodeWithMemberId(request.participantCode(),
-                        request.memberId()));
-    }
-
-    @PostMapping("/api/v2/studies/authenticate")
-    public ResponseEntity<FindRoomResponse> checkAuthV2(
-            @Valid @RequestBody FindRoomRequest request
-    ) {
-        return ResponseEntity.ok(null);
+    public ResponseEntity<FindRoomResponse> checkAuth(@Valid @RequestBody FindRoomRequest request) {
+        return ResponseEntity.ok(participantCodeService.findRoomByCode(request.participantCode()));
     }
 }

--- a/backend/src/main/java/harustudy/backend/participantcode/service/ParticipantCodeService.java
+++ b/backend/src/main/java/harustudy/backend/participantcode/service/ParticipantCodeService.java
@@ -4,6 +4,7 @@ import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.repository.MemberRepository;
 import harustudy.backend.participantcode.domain.ParticipantCode;
 import harustudy.backend.participantcode.dto.FindRoomAndNicknameResponse;
+import harustudy.backend.participantcode.dto.FindRoomResponse;
 import harustudy.backend.participantcode.repository.ParticipantCodeRepository;
 import harustudy.backend.room.domain.Room;
 import harustudy.backend.room.repository.RoomRepository;
@@ -34,10 +35,10 @@ public class ParticipantCodeService {
         return new FindRoomAndNicknameResponse(room.getId(), room.getName(), member.getNickname());
     }
 
-    public FindRoomAndNicknameResponse findRoomByCode(String code) {
+    public FindRoomResponse findRoomByCode(String code) {
         ParticipantCode participantCode = participantCodeRepository.findByCode(code)
                 .orElseThrow(IllegalArgumentException::new);
         Room room = roomRepository.findByParticipantCode(participantCode);
-        return new FindRoomAndNicknameResponse(room.getId(), room.getName());
+        return new FindRoomResponse(room.getId(), room.getName());
     }
 }

--- a/backend/src/main/java/harustudy/backend/room/controller/RoomController.java
+++ b/backend/src/main/java/harustudy/backend/room/controller/RoomController.java
@@ -41,27 +41,10 @@ public class RoomController {
     @PostMapping("/api/studies/{studyId}/members")
     public ResponseEntity<Void> participate(
             @PathVariable Long studyId,
-            @RequestBody ParticipateRequest request
-    ) {
-        Long memberId = roomService.participate(studyId, request.nickname());
-        return ResponseEntity.created(
-                URI.create("/api/studies/" + studyId + "/members/" + memberId)).build();
-    }
-
-    @PostMapping("/api/v2/studies/{studyId}/participate")
-    public ResponseEntity<Void> participateV2(
-            @PathVariable Long studyId,
             @Valid @RequestBody ParticipateRequest request
     ) {
+        roomService.participate(studyId, request.nickname());
         return ResponseEntity.created(
                 URI.create("/api/studies/" + studyId + "/members/")).build();
-    }
-
-    @PostMapping("/api/v2/studies/{studyId}/reparticipate")
-    public ResponseEntity<Void> reParticipateV2(
-            @PathVariable Long studyId,
-            @Valid @RequestBody ReParticipateRequest request
-    ) {
-        return ResponseEntity.ok(null);
     }
 }

--- a/backend/src/test/java/harustudy/backend/integration/AuthenticateIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/AuthenticateIntegrationTest.java
@@ -1,0 +1,49 @@
+package harustudy.backend.integration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import harustudy.backend.participantcode.dto.FindRoomRequest;
+import harustudy.backend.participantcode.dto.FindRoomResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class AuthenticateIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 참여코드를_인증하고_스터디_정보를_반환한다() throws Exception {
+        // given
+        FindRoomRequest request = new FindRoomRequest(participantCode.getCode());
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        // when
+        MvcResult result = mockMvc.perform(
+                        post("/api/studies/authenticate")
+                                .content(jsonRequest)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        String jsonResponse = result.getResponse().getContentAsString();
+        FindRoomResponse response = objectMapper.readValue(jsonResponse,
+                FindRoomResponse.class);
+
+        assertAll(
+                () -> assertThat(response.studyId()).isEqualTo(room.getId()),
+                () -> assertThat(response.studyName()).isEqualTo(room.getName())
+        );
+    }
+}

--- a/backend/src/test/java/harustudy/backend/integration/ParticipateRoomIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ParticipateRoomIntegrationTest.java
@@ -1,13 +1,10 @@
 package harustudy.backend.integration;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import harustudy.backend.participantcode.dto.FindRoomAndNicknameRequest;
-import harustudy.backend.participantcode.dto.FindRoomAndNicknameResponse;
 import harustudy.backend.room.dto.ParticipateRequest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -22,60 +19,6 @@ public class ParticipateRoomIntegrationTest extends IntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Test
-    void 기존_참여멤버의_참여코드를_인증하고_스터디와_멤버_정보를_반환한다() throws Exception {
-        // given
-        FindRoomAndNicknameRequest request = new FindRoomAndNicknameRequest(
-                participantCode.getCode(), member.getId());
-        String jsonRequest = objectMapper.writeValueAsString(request);
-
-        // when
-        MvcResult result = mockMvc.perform(
-                        post("/api/studies/authenticate")
-                                .content(jsonRequest)
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // then
-        String jsonResponse = result.getResponse().getContentAsString();
-        FindRoomAndNicknameResponse response = objectMapper.readValue(jsonResponse,
-                FindRoomAndNicknameResponse.class);
-
-        assertAll(
-                () -> assertThat(response.studyId()).isEqualTo(room.getId()),
-                () -> assertThat(response.studyName()).isEqualTo(room.getName()),
-                () -> assertThat(response.nickname()).isEqualTo(member.getNickname())
-        );
-    }
-
-    @Test
-    void 신규멤버의_참여코드를_인증하고_스터디_정보를_반환한다() throws Exception {
-        // given
-        FindRoomAndNicknameRequest request = new FindRoomAndNicknameRequest(
-                participantCode.getCode(), null);
-        String jsonRequest = objectMapper.writeValueAsString(request);
-
-        // when
-        MvcResult result = mockMvc.perform(
-                        post("/api/studies/authenticate")
-                                .content(jsonRequest)
-                                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // then
-        String jsonResponse = result.getResponse().getContentAsString();
-        FindRoomAndNicknameResponse response = objectMapper.readValue(jsonResponse,
-                FindRoomAndNicknameResponse.class);
-
-        assertAll(
-                () -> assertThat(response.studyId()).isEqualTo(room.getId()),
-                () -> assertThat(response.studyName()).isEqualTo(room.getName()),
-                () -> assertThat(response.nickname()).isNull()
-        );
-    }
 
     @Test
     void 신규멤버_닉네임을_통해_멤버_생성하고_스터디에_참여한다() throws Exception {

--- a/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
@@ -8,6 +8,7 @@ import harustudy.backend.member.domain.Member;
 import harustudy.backend.participantcode.domain.CodeGenerationStrategy;
 import harustudy.backend.participantcode.domain.ParticipantCode;
 import harustudy.backend.participantcode.dto.FindRoomAndNicknameResponse;
+import harustudy.backend.participantcode.dto.FindRoomResponse;
 import harustudy.backend.progress.domain.PomodoroProgress;
 import harustudy.backend.room.domain.PomodoroRoom;
 import harustudy.backend.room.domain.Room;
@@ -69,14 +70,11 @@ class ParticipantCodeServiceTest {
         entityManager.persist(room);
 
         // when
-        FindRoomAndNicknameResponse response = participantCodeService.findRoomByCode(
+        FindRoomResponse response = participantCodeService.findRoomByCode(
                 code.getCode());
 
         // then
-        assertAll(
-                () -> assertThat(response.studyName()).isEqualTo("room"),
-                () -> assertThat(response.nickname()).isNull()
-        );
+        assertThat(response.studyName()).isEqualTo("room");
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- closed #171 

## 구현 기능 및 변경 사항
### 기존 API (/api/studies/authenticate)
- 참여코드와 멤버 ID를 받아서 참여코드 인증을 통해 스터디 정보와 멤버 닉네임을 받아오는 API 
  - memberId가 쿠키에 있으면 같이 받아서 닉네임도 반환했었음.
  - memberId가 쿠키에 없으면 빼고 스터디 정보만 반환했었음.

### 수정된 API (/api/studies/authenticate)
- 참여코드를 받아서 인증을 통해 스터디 정보를 받아오는 API 


![image](https://github.com/woowacourse-teams/2023-haru-study/assets/31722737/e0ec531b-e0e3-4ecb-8f93-5018aeed55b9)


### 프론트 수정사항
- 스터디 코드 인증 후 기존 멤버일 때 `처음부터 진행하기`, `이어서 진행하기` 두 개의 선택지가 있음.
  - 처음부터 진행하기 : 아무런 API 요청 없이 다시 닉네임을 입력받도록 하면 된다. (지금 플로우 그대로 유지하면 됨)
  - 이어서 진행하기 : 현재 participate + study metadata 조회 처럼 두 번의 API 요청이 되는 것으로 예상되는데 participate 요청 없이 study metadata 조회만 하도록 수정