### PR TITLE
[FE] 브라우저 비활성탭일 때 타이머 시간 느리게 가는 버그 수정

### DIFF
--- a/frontend/src/hooks/board/useStudyBoard.ts
+++ b/frontend/src/hooks/board/useStudyBoard.ts
@@ -16,7 +16,10 @@ const useStudyBoard = () => {
 
   useEffect(() => {
     const fetchStudyMetaData = async () => {
-      if (!studyId || !memberId) throw new Error('정상적인 경로로 접근해주세요.');
+      if (!studyId || !memberId) {
+        setError(new Error('정상적인 경로로 접근해주세요.'));
+        return;
+      }
 
       const fetchedData = await requestGetMemberStudyMetadata(studyId, memberId);
       setStudyData({ ...fetchedData, studyId, memberId });

--- a/frontend/src/hooks/board/useTimer.ts
+++ b/frontend/src/hooks/board/useTimer.ts
@@ -7,9 +7,10 @@ const SECONDS_PER_MINUTE = 60;
 
 const useTimer = (studyMinutes: number, step: Step) => {
   const timerId = useRef<NodeJS.Timer | null>(null);
+  const startTime = useRef(Date.now());
+  const initTime = useRef(PLANNING_MINUTES * SECONDS_PER_MINUTE);
 
-  const initialMinutes = PLANNING_MINUTES * SECONDS_PER_MINUTE;
-  const [leftTime, setLeftTime] = useState(initialMinutes);
+  const [leftTime, setLeftTime] = useState(initTime.current);
   const [isTicking, setIsTicking] = useState(false);
 
   const clear = () => {
@@ -21,7 +22,9 @@ const useTimer = (studyMinutes: number, step: Step) => {
 
   const tick = useCallback(() => {
     if (leftTime > 0) {
-      setLeftTime(leftTime - 1);
+      const timeDifference = Math.floor((Date.now() - startTime.current) / 1000);
+
+      setLeftTime(initTime.current - timeDifference);
     }
     if (leftTime <= 1) {
       setIsTicking(false);
@@ -41,18 +44,22 @@ const useTimer = (studyMinutes: number, step: Step) => {
     setIsTicking(false);
 
     if (step === 'planning' || step === 'retrospect') {
+      initTime.current = PLANNING_MINUTES * SECONDS_PER_MINUTE;
       setLeftTime(PLANNING_MINUTES * SECONDS_PER_MINUTE);
       return;
     }
 
+    initTime.current = studyMinutes * SECONDS_PER_MINUTE;
     setLeftTime(studyMinutes * SECONDS_PER_MINUTE);
   }, [studyMinutes, step]);
 
   const start = () => {
+    startTime.current = Date.now();
     setIsTicking(true);
   };
 
   const stop = () => {
+    initTime.current = leftTime;
     setIsTicking(false);
   };
 


### PR DESCRIPTION
## 관련 이슈
closed #251 

## 구현 기능 및 변경 사항
- 타이머 시간 느리게 가는 버그 수정
- 진행 페이지에서 memberId 혹은 studyId가 잘못되었을 경우 무한 로딩에 빠지는 문제 수정

## 스크린샷(선택)