### PR TITLE
[BE] memberId가 이미 있지만 다른 스터디를 참여할 때 null이 아닌 404내려주는 문제

### DIFF
--- a/backend/src/main/java/harustudy/backend/member/service/MemberService.java
+++ b/backend/src/main/java/harustudy/backend/member/service/MemberService.java
@@ -4,9 +4,7 @@ import harustudy.backend.common.EntityNotFoundException.MemberNotFound;
 import harustudy.backend.common.EntityNotFoundException.RoomNotFound;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.dto.NicknameResponse;
-import harustudy.backend.member.exception.MemberNotParticipatedException;
 import harustudy.backend.member.repository.MemberRepository;
-import harustudy.backend.progress.repository.PomodoroProgressRepository;
 import harustudy.backend.room.domain.PomodoroRoom;
 import harustudy.backend.room.repository.PomodoroRoomRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +19,6 @@ public class MemberService {
 
     private final PomodoroRoomRepository pomodoroRoomRepository;
     private final MemberRepository memberRepository;
-    private final PomodoroProgressRepository pomodoroProgressRepository;
 
     public NicknameResponse findParticipatedMemberNickname(Long roomId, Long memberId) {
         PomodoroRoom pomodoroRoom = pomodoroRoomRepository.findById(roomId)
@@ -29,9 +26,9 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFound::new);
 
-        pomodoroProgressRepository.findByPomodoroRoomAndMember(pomodoroRoom, member)
-                .orElseThrow(MemberNotParticipatedException::new);
-
-        return new NicknameResponse(member.getNickname());
+        if (pomodoroRoom.isParticipatedMember(member)) {
+            return new NicknameResponse(member.getNickname());
+        }
+        return new NicknameResponse(null);
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed: #257 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 404와 code:1000이 아닌 nickname에 Null을 반환하도록 변경

