### PR TITLE
[FE] 스터디 기록 페이지 API 훅 분리 및 v2 적용

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -79,10 +79,11 @@ export const requestGetStudyingContent = (studyId: string, memberId: string, cyc
 export const requestSubmitStudyingForm = (studyId: string, memberId: string) =>
   http.post(`/api/studies/${studyId}/members/${memberId}/next-step`);
 
-// RecordContents
-export const requestGetStudyMetadata = (studyId: string) =>
-  http.get<ResponseStudyMetadata>(`/api/studies/${studyId}/metadata`);
+export const requestGetStudyData = (studyId: string) =>
+  http.get<Omit<ResponseStudyMetadata, 'member'>>(`/api/v2/studies/${studyId}`);
 
-// MemberRecord
+export const requestGetStudyMembers = (studyId: string) =>
+  http.get<Pick<ResponseStudyMetadata, 'members'>>(`/api/v2/members?studyId=${studyId}`);
+
 export const requestGetMemberRecordContents = (studyId: string, memberId: string) =>
-  http.get<ResponseMemberRecordContents>(`/api/studies/${studyId}/members/${memberId}/content`);
+  http.get<ResponseMemberRecordContents>(`/api/v2/studies/${studyId}/contents?memberId=${memberId}`);

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -11,6 +11,8 @@ import type {
 } from '@Types/api';
 import type { PlanList, RetrospectList, StudyTimePerCycleOptions, TotalCycleOptions } from '@Types/study';
 
+const BASE_URL = '/api/v2';
+
 export const requestCreateStudy = async (
   studyName: string,
   totalCycle: TotalCycleOptions,
@@ -80,10 +82,10 @@ export const requestSubmitStudyingForm = (studyId: string, memberId: string) =>
   http.post(`/api/studies/${studyId}/members/${memberId}/next-step`);
 
 export const requestGetStudyData = (studyId: string) =>
-  http.get<Omit<ResponseStudyMetadata, 'member'>>(`/api/v2/studies/${studyId}`);
+  http.get<Omit<ResponseStudyMetadata, 'member'>>(`${BASE_URL}/studies/${studyId}`);
 
 export const requestGetStudyMembers = (studyId: string) =>
-  http.get<Pick<ResponseStudyMetadata, 'members'>>(`/api/v2/members?studyId=${studyId}`);
+  http.get<Pick<ResponseStudyMetadata, 'members'>>(`${BASE_URL}/members?studyId=${studyId}`);
 
 export const requestGetMemberRecordContents = (studyId: string, memberId: string) =>
-  http.get<ResponseMemberRecordContents>(`/api/v2/studies/${studyId}/contents?memberId=${memberId}`);
+  http.get<ResponseMemberRecordContents>(`${BASE_URL}/studies/${studyId}/contents?memberId=${memberId}`);

--- a/frontend/src/components/record/MemberRecord/MemberRecord.tsx
+++ b/frontend/src/components/record/MemberRecord/MemberRecord.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 
 import QuestionAnswer from '@Components/common/QuestionAnswer/QuestionAnswer';
 import Tabs from '@Components/common/Tabs/Tabs';
 import TabsSkeleton from '@Components/common/Tabs/TabsSkeleton';
 import Typography from '@Components/common/Typography/Typography';
+
+import useMemberRecord from '@Hooks/record/useMemberRecord';
 
 import color from '@Styles/color';
 
@@ -15,9 +16,7 @@ import PencilIcon from '@Assets/icons/PencilIcon';
 
 import { getKeys } from '@Utils/getKeys';
 
-import { requestGetMemberRecordContents } from '@Apis/index';
-
-import type { MemberRecordContent, Plan, Retrospect } from '@Types/study';
+import type { Plan, Retrospect } from '@Types/study';
 
 type Props = {
   studyId: string;
@@ -26,24 +25,7 @@ type Props = {
 };
 
 const MemberRecord = ({ studyId, nickname, memberId }: Props) => {
-  const [memberRecordContents, setMemberRecordContents] = useState<MemberRecordContent[] | null>(null);
-
-  const isLoading = !memberRecordContents;
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const data = await requestGetMemberRecordContents(studyId, memberId);
-
-      setMemberRecordContents(data.content);
-    };
-
-    try {
-      fetchData();
-    } catch (error) {
-      if (!(error instanceof Error)) throw error;
-      alert(error.message);
-    }
-  }, [memberId, studyId]);
+  const { memberRecordContents, isLoading } = useMemberRecord(studyId, memberId);
 
   if (isLoading) {
     return <TabsSkeleton />;

--- a/frontend/src/components/record/MemberRecord/MemberRecord.tsx
+++ b/frontend/src/components/record/MemberRecord/MemberRecord.tsx
@@ -25,7 +25,9 @@ type Props = {
 };
 
 const MemberRecord = ({ studyId, nickname, memberId }: Props) => {
-  const { memberRecordContents, isLoading } = useMemberRecord(studyId, memberId);
+  const { memberRecordContents, isLoading } = useMemberRecord(studyId, memberId, {
+    errorHandler: (error) => alert(error.message),
+  });
 
   if (isLoading) {
     return <TabsSkeleton />;

--- a/frontend/src/components/record/MemberRecordList/MemberRecordList.tsx
+++ b/frontend/src/components/record/MemberRecordList/MemberRecordList.tsx
@@ -7,10 +7,11 @@ import MemberRecord from '../MemberRecord/MemberRecord';
 type Props = {
   members: { memberId: string; nickname: string }[];
   studyId?: string;
+  isLoading: boolean;
 };
 
-const MemberRecordList = ({ members = [], studyId = '' }: Props) => {
-  if (members.length === 0) {
+const MemberRecordList = ({ members = [], studyId = '', isLoading }: Props) => {
+  if (isLoading) {
     return <AccordionSkeleton />;
   }
 

--- a/frontend/src/components/record/RecordContents/RecordContents.tsx
+++ b/frontend/src/components/record/RecordContents/RecordContents.tsx
@@ -1,40 +1,19 @@
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { requestGetStudyMetadata } from '@Apis/index';
-
-import type { Member, StudyBasicInfo } from '@Types/study';
+import useStudyRecord from '@Hooks/record/useStudyRecord';
 
 import MemberRecordList from '../MemberRecordList/MemberRecordList';
 import StudyInformation from '../StudyInformation/StudyInformation';
 
 const RecordContents = () => {
   const { studyId } = useParams<{ studyId: string }>();
-  const [studyBasicInfo, setStudyBasicInfo] = useState<StudyBasicInfo | null>(null);
-  const [members, setMembers] = useState<Member[]>([]);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      if (!studyId) throw Error('잘못된 접근입니다.');
+  if (!studyId) throw Error('잘못된 접근입니다.');
 
-      const { studyName, timePerCycle, totalCycle, members } = await requestGetStudyMetadata(studyId);
-
-      setStudyBasicInfo({
-        studyName,
-        timePerCycle,
-        totalCycle,
-      });
-      setMembers(members);
-    };
-
-    try {
-      fetchData();
-    } catch (error) {
-      if (!(error instanceof Error)) throw error;
-      alert(error.message);
-    }
-  }, [studyId]);
+  const { isLoading, studyBasicInfo, members } = useStudyRecord(studyId, {
+    errorHandler: (message) => alert(message),
+  });
 
   return (
     <RecordContentsLayout>
@@ -42,9 +21,9 @@ const RecordContents = () => {
         studyName={studyBasicInfo?.studyName}
         totalCycle={studyBasicInfo?.totalCycle}
         timePerCycle={studyBasicInfo?.timePerCycle}
-        $isLoading={!studyBasicInfo}
+        $isLoading={isLoading}
       />
-      <MemberRecordList studyId={studyId} members={members} />
+      <MemberRecordList studyId={studyId} members={members} isLoading={isLoading} />
     </RecordContentsLayout>
   );
 };

--- a/frontend/src/components/record/RecordContents/RecordContents.tsx
+++ b/frontend/src/components/record/RecordContents/RecordContents.tsx
@@ -12,7 +12,7 @@ const RecordContents = () => {
   if (!studyId) throw Error('잘못된 접근입니다.');
 
   const { isLoading, studyBasicInfo, members } = useStudyRecord(studyId, {
-    errorHandler: (message) => alert(message),
+    errorHandler: (error) => alert(error.message),
   });
 
   return (

--- a/frontend/src/hooks/record/useMemberRecord.ts
+++ b/frontend/src/hooks/record/useMemberRecord.ts
@@ -1,10 +1,11 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useCallback, useEffect, useState } from 'react';
 
 import { requestGetMemberRecordContents } from '@Apis/index';
 
 import type { MemberRecordContent } from '@Types/study';
 
-const useMemberRecord = (studyId: string, memberId: string) => {
+const useMemberRecord = (studyId: string, memberId: string, options?: { errorHandler: (error: Error) => void }) => {
   const [memberRecordContents, setMemberRecordContents] = useState<MemberRecordContent[] | null>(null);
 
   const isLoading = !memberRecordContents;
@@ -16,7 +17,8 @@ const useMemberRecord = (studyId: string, memberId: string) => {
       setMemberRecordContents(content);
     } catch (error) {
       if (!(error instanceof Error)) throw error;
-      alert(error.message);
+
+      options?.errorHandler(error);
     }
   }, [memberId, studyId]);
 

--- a/frontend/src/hooks/record/useMemberRecord.ts
+++ b/frontend/src/hooks/record/useMemberRecord.ts
@@ -10,7 +10,7 @@ const useMemberRecord = (studyId: string, memberId: string, options?: { errorHan
 
   const isLoading = !memberRecordContents;
 
-  const fetchData = useCallback(async () => {
+  const fetchMemberRecordData = useCallback(async () => {
     try {
       const { content } = await requestGetMemberRecordContents(studyId, memberId);
 
@@ -23,8 +23,8 @@ const useMemberRecord = (studyId: string, memberId: string, options?: { errorHan
   }, [memberId, studyId]);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    fetchMemberRecordData();
+  }, [fetchMemberRecordData]);
 
   return { memberRecordContents, isLoading };
 };

--- a/frontend/src/hooks/record/useMemberRecord.ts
+++ b/frontend/src/hooks/record/useMemberRecord.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { requestGetMemberRecordContents } from '@Apis/index';
+
+import type { MemberRecordContent } from '@Types/study';
+
+const useMemberRecord = (studyId: string, memberId: string) => {
+  const [memberRecordContents, setMemberRecordContents] = useState<MemberRecordContent[] | null>(null);
+
+  const isLoading = !memberRecordContents;
+
+  const fetchData = useCallback(async () => {
+    try {
+      const { content } = await requestGetMemberRecordContents(studyId, memberId);
+
+      setMemberRecordContents(content);
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      alert(error.message);
+    }
+  }, [memberId, studyId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { memberRecordContents, isLoading };
+};
+
+export default useMemberRecord;

--- a/frontend/src/hooks/record/useStudyRecord.ts
+++ b/frontend/src/hooks/record/useStudyRecord.ts
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { requestGetStudyMetadata } from '@Apis/index';
 
@@ -10,7 +10,7 @@ const useStudyRecord = (studyId: string, options?: { errorHandler: (message: str
   const [studyBasicInfo, setStudyBasicInfo] = useState<StudyBasicInfo | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     try {
       const { studyName, timePerCycle, totalCycle, members } = await requestGetStudyMetadata(studyId);
 
@@ -27,11 +27,11 @@ const useStudyRecord = (studyId: string, options?: { errorHandler: (message: str
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [studyId]);
 
   useEffect(() => {
     fetchData();
-  }, [studyId]);
+  }, [fetchData]);
 
   return { isLoading, studyBasicInfo, members };
 };

--- a/frontend/src/hooks/record/useStudyRecord.ts
+++ b/frontend/src/hooks/record/useStudyRecord.ts
@@ -1,0 +1,39 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from 'react';
+
+import { requestGetStudyMetadata } from '@Apis/index';
+
+import type { Member, StudyBasicInfo } from '@Types/study';
+
+const useStudyRecord = (studyId: string, options?: { errorHandler: (message: string) => void }) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [studyBasicInfo, setStudyBasicInfo] = useState<StudyBasicInfo | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+
+  const fetchData = async () => {
+    try {
+      const { studyName, timePerCycle, totalCycle, members } = await requestGetStudyMetadata(studyId);
+
+      setStudyBasicInfo({
+        studyName,
+        timePerCycle,
+        totalCycle,
+      });
+      setMembers(members);
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+
+      options?.errorHandler(error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [studyId]);
+
+  return { isLoading, studyBasicInfo, members };
+};
+
+export default useStudyRecord;

--- a/frontend/src/hooks/record/useStudyRecord.ts
+++ b/frontend/src/hooks/record/useStudyRecord.ts
@@ -5,7 +5,7 @@ import { requestGetStudyMetadata } from '@Apis/index';
 
 import type { Member, StudyBasicInfo } from '@Types/study';
 
-const useStudyRecord = (studyId: string, options?: { errorHandler: (message: string) => void }) => {
+const useStudyRecord = (studyId: string, options?: { errorHandler: (error: Error) => void }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [studyBasicInfo, setStudyBasicInfo] = useState<StudyBasicInfo | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
@@ -23,7 +23,7 @@ const useStudyRecord = (studyId: string, options?: { errorHandler: (message: str
     } catch (error) {
       if (!(error instanceof Error)) throw error;
 
-      options?.errorHandler(error.message);
+      options?.errorHandler(error);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/hooks/record/useStudyRecord.ts
+++ b/frontend/src/hooks/record/useStudyRecord.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useCallback, useEffect, useState } from 'react';
 
-import { requestGetStudyMetadata } from '@Apis/index';
+import { requestGetStudyData, requestGetStudyMembers } from '@Apis/index';
 
 import type { Member, StudyBasicInfo } from '@Types/study';
 
@@ -12,7 +12,8 @@ const useStudyRecord = (studyId: string, options?: { errorHandler: (error: Error
 
   const fetchData = useCallback(async () => {
     try {
-      const { studyName, timePerCycle, totalCycle, members } = await requestGetStudyMetadata(studyId);
+      const { studyName, timePerCycle, totalCycle } = await requestGetStudyData(studyId);
+      const { members } = await requestGetStudyMembers(studyId);
 
       setStudyBasicInfo({
         studyName,

--- a/frontend/src/hooks/record/useStudyRecord.ts
+++ b/frontend/src/hooks/record/useStudyRecord.ts
@@ -10,7 +10,7 @@ const useStudyRecord = (studyId: string, options?: { errorHandler: (error: Error
   const [studyBasicInfo, setStudyBasicInfo] = useState<StudyBasicInfo | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
 
-  const fetchData = useCallback(async () => {
+  const fetchStudyRecordData = useCallback(async () => {
     try {
       const { studyName, timePerCycle, totalCycle } = await requestGetStudyData(studyId);
       const { members } = await requestGetStudyMembers(studyId);
@@ -31,8 +31,8 @@ const useStudyRecord = (studyId: string, options?: { errorHandler: (error: Error
   }, [studyId]);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    fetchStudyRecordData();
+  }, [fetchStudyRecordData]);
 
   return { isLoading, studyBasicInfo, members };
 };

--- a/frontend/src/mocks/handlers/studyRecordHandlers.ts
+++ b/frontend/src/mocks/handlers/studyRecordHandlers.ts
@@ -54,10 +54,7 @@ const STUDY_CONTENT = {
   ],
 };
 
-const STUDY_METADATA = {
-  studyName: '안오면 지상렬',
-  totalCycle: 3,
-  timePerCycle: 25,
+const STUDY_MEMBERS = {
   members: [
     {
       memberId: 1,
@@ -90,12 +87,22 @@ const STUDY_METADATA = {
   ],
 };
 
+const STUDY_METADATA = {
+  studyName: '안오면 지상렬',
+  totalCycle: 3,
+  timePerCycle: 25,
+};
+
 export const studyRecordHandlers = [
-  rest.get('/api/studies/:studyId/metadata', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(STUDY_METADATA), ctx.delay(800));
+  rest.get('/api/v2/studies/:studyId', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(STUDY_METADATA), ctx.delay(400));
   }),
 
-  rest.get('/api/studies/:studyId/members/:memberId/content', (req, res, ctx) => {
+  rest.get('/api/v2/members?studyId=1', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(STUDY_MEMBERS), ctx.delay(400));
+  }),
+
+  rest.get('/api/v2/studies/:studyId/contents?memberId=1', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(STUDY_CONTENT), ctx.delay(800));
   }),
 ];


### PR DESCRIPTION
## 관련 이슈
closed #261

## 구현 기능 및 변경 사항

- hooks/record 폴더에 `useStudyRecord`, `useMemberRecord` 훅을 만들어 api 통신 로직을 분리
- 스터디 기록 페이지와 관련된 api를 `v2` 로 적용 및 msw 수정

## 스크린샷(선택)