### PR TITLE
[BE] 객체지향적 설계로의 변경 PR close를 위한 정리

### DIFF
--- a/backend/src/main/java/harustudy/backend/content/service/PomodoroContentService.java
+++ b/backend/src/main/java/harustudy/backend/content/service/PomodoroContentService.java
@@ -55,7 +55,7 @@ public class PomodoroContentService {
     }
 
     private void validateProgressIsPlanning(PomodoroProgress pomodoroProgress) {
-        if (pomodoroProgress.isNotPlanning()) {
+        if (!pomodoroProgress.isPlanning()) {
             throw new PomodoroProgressStatusException();
         }
     }
@@ -113,7 +113,7 @@ public class PomodoroContentService {
     }
 
     private void validateProgressIsRetrospect(PomodoroProgress pomodoroProgress) {
-        if (pomodoroProgress.isNotRetrospect()) {
+        if (!pomodoroProgress.isRetrospect()) {
             throw new UnavailableToProceed(); // TODO: 예외 세분화
         }
     }

--- a/backend/src/main/java/harustudy/backend/content/service/PomodoroContentServiceV2.java
+++ b/backend/src/main/java/harustudy/backend/content/service/PomodoroContentServiceV2.java
@@ -41,7 +41,7 @@ public class PomodoroContentServiceV2 {
     }
 
     private void validateProgressIsPlanning(PomodoroProgress pomodoroProgress) {
-        if (pomodoroProgress.isNotPlanning()) {
+        if (!pomodoroProgress.isPlanning()) {
             throw new PomodoroProgressStatusException();
         }
     }
@@ -65,7 +65,7 @@ public class PomodoroContentServiceV2 {
     }
 
     private void validateProgressIsRetrospect(PomodoroProgress pomodoroProgress) {
-        if (pomodoroProgress.isNotRetrospect()) {
+        if (!pomodoroProgress.isRetrospect()) {
             throw new PomodoroProgressStatusException();
         }
     }

--- a/backend/src/main/java/harustudy/backend/member/service/MemberServiceV2.java
+++ b/backend/src/main/java/harustudy/backend/member/service/MemberServiceV2.java
@@ -47,7 +47,7 @@ public class MemberServiceV2 {
         Member member = memberRepository.save(new Member(request.nickname()));
         PomodoroRoom pomodoroRoom = pomodoroRoomRepository.findById(request.studyId())
                 .orElseThrow(RoomNotFoundException::new);
-        pomodoroProgressRepository.save(new PomodoroProgress(pomodoroRoom, member));
+        pomodoroRoom.createProgress(member);
         return member.getId();
     }
 }

--- a/backend/src/main/java/harustudy/backend/member/service/MemberServiceV2.java
+++ b/backend/src/main/java/harustudy/backend/member/service/MemberServiceV2.java
@@ -1,7 +1,5 @@
 package harustudy.backend.member.service;
 
-import harustudy.backend.content.domain.PomodoroContent;
-import harustudy.backend.content.repository.PomodoroContentRepository;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.dto.GuestRegisterRequest;
 import harustudy.backend.member.dto.MemberResponseV2;
@@ -26,7 +24,6 @@ public class MemberServiceV2 {
     private final MemberRepository memberRepository;
     private final PomodoroRoomRepository pomodoroRoomRepository;
     private final PomodoroProgressRepository pomodoroProgressRepository;
-    private final PomodoroContentRepository pomodoroContentRepository;
 
     public MemberResponseV2 findMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -50,13 +47,7 @@ public class MemberServiceV2 {
         Member member = memberRepository.save(new Member(request.nickname()));
         PomodoroRoom pomodoroRoom = pomodoroRoomRepository.findById(request.studyId())
                 .orElseThrow(RoomNotFoundException::new);
-        Integer totalCycle = pomodoroRoom.getTotalCycle();
-
-        PomodoroProgress pomodoroProgress = pomodoroProgressRepository.save(
-                new PomodoroProgress(pomodoroRoom, member));
-        for (int i = 1; i <= totalCycle; i++) {
-            pomodoroContentRepository.save(new PomodoroContent(pomodoroProgress, i));
-        }
+        pomodoroProgressRepository.save(new PomodoroProgress(pomodoroRoom, member));
         return member.getId();
     }
 }

--- a/backend/src/main/java/harustudy/backend/progress/domain/PomodoroProgress.java
+++ b/backend/src/main/java/harustudy/backend/progress/domain/PomodoroProgress.java
@@ -40,7 +40,7 @@ public class PomodoroProgress extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "pomodoroProgress", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "pomodoroProgress", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<PomodoroContent> pomodoroContents = new ArrayList<>();
 
     private boolean isDone = false;
@@ -57,6 +57,14 @@ public class PomodoroProgress extends BaseTimeEntity {
         this.currentCycle = 1;
         this.pomodoroStatus = PomodoroStatus.PLANNING;
         makeContentsByTotalCycle(pomodoroRoom.getTotalCycle());
+    }
+
+    public PomodoroProgress(PomodoroRoom pomodoroRoom, Member member, Integer totalCycle) {
+        this.pomodoroRoom = pomodoroRoom;
+        this.member = member;
+        this.currentCycle = 1;
+        this.pomodoroStatus = PomodoroStatus.PLANNING;
+        makeContentsByTotalCycle(totalCycle);
     }
 
     // TODO: 없애기

--- a/backend/src/main/java/harustudy/backend/progress/domain/PomodoroProgress.java
+++ b/backend/src/main/java/harustudy/backend/progress/domain/PomodoroProgress.java
@@ -4,6 +4,7 @@ import harustudy.backend.common.BaseTimeEntity;
 import harustudy.backend.content.domain.PomodoroContent;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.room.domain.PomodoroRoom;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -39,7 +40,7 @@ public class PomodoroProgress extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "pomodoroProgress")
+    @OneToMany(mappedBy = "pomodoroProgress", cascade = CascadeType.ALL)
     private List<PomodoroContent> pomodoroContents = new ArrayList<>();
 
     private boolean isDone = false;
@@ -55,6 +56,7 @@ public class PomodoroProgress extends BaseTimeEntity {
         this.member = member;
         this.currentCycle = 1;
         this.pomodoroStatus = PomodoroStatus.PLANNING;
+        makeContentsByTotalCycle(pomodoroRoom.getTotalCycle());
     }
 
     // TODO: 없애기
@@ -64,6 +66,12 @@ public class PomodoroProgress extends BaseTimeEntity {
         this.member = member;
         this.currentCycle = currentCycle;
         this.pomodoroStatus = pomodoroStatus;
+    }
+
+    private void makeContentsByTotalCycle(Integer totalCycle) {
+        for (int i = 0; i < totalCycle; i++) {
+            pomodoroContents.add(new PomodoroContent(this, i));
+        }
     }
 
     public boolean isOwnedBy(Member member) {
@@ -110,19 +118,15 @@ public class PomodoroProgress extends BaseTimeEntity {
         pomodoroStatus = pomodoroStatus.getNext();
     }
 
+    public boolean isPlanning() {
+        return pomodoroStatus == PomodoroStatus.PLANNING;
+    }
+
+    public boolean isStudying() {
+        return pomodoroStatus == PomodoroStatus.STUDYING;
+    }
+
     public boolean isRetrospect() {
         return pomodoroStatus == PomodoroStatus.RETROSPECT;
-    }
-
-    public boolean isNotPlanning() {
-        return pomodoroStatus != PomodoroStatus.PLANNING;
-    }
-
-    public boolean isNotStudying() {
-        return pomodoroStatus != PomodoroStatus.STUDYING;
-    }
-
-    public boolean isNotRetrospect() {
-        return pomodoroStatus != PomodoroStatus.RETROSPECT;
     }
 }

--- a/backend/src/main/java/harustudy/backend/progress/service/PomodoroProgressService.java
+++ b/backend/src/main/java/harustudy/backend/progress/service/PomodoroProgressService.java
@@ -47,7 +47,7 @@ public class PomodoroProgressService {
     }
 
     private void validateProgressIsStudying(PomodoroProgress pomodoroProgress) {
-        if (pomodoroProgress.isNotStudying()) {
+        if (!pomodoroProgress.isStudying()) {
             throw new UnavailableToProceed();
         }
     }

--- a/backend/src/main/java/harustudy/backend/room/domain/PomodoroRoom.java
+++ b/backend/src/main/java/harustudy/backend/room/domain/PomodoroRoom.java
@@ -49,7 +49,7 @@ public class PomodoroRoom extends BaseTimeEntity {
     @NotNull
     private Integer timePerCycle;
 
-    @OneToMany(mappedBy = "pomodoroRoom")
+    @OneToMany(mappedBy = "pomodoroRoom", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<PomodoroProgress> pomodoroProgresses = new ArrayList<>();
 
     public PomodoroRoom(@NotNull String name, @NotNull Integer totalCycle,
@@ -95,5 +95,11 @@ public class PomodoroRoom extends BaseTimeEntity {
                 .anyMatch(memberProgress -> memberProgress.hasSameNicknameMember(member))) {
             throw new DuplicatedNicknameException();
         }
+    }
+
+    public PomodoroProgress createProgress(Member member) {
+        PomodoroProgress pomodoroProgress = new PomodoroProgress(this, member, totalCycle);
+        pomodoroProgresses.add(pomodoroProgress);
+        return pomodoroProgress;
     }
 }


### PR DESCRIPTION
# 해당 PR은 이전 논의되었던 PR을 정리하기 위한 용도이니 merge하시면 안됩니다!

## 관련 PR
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #198 

<br/>

## 이전 PR 내용 정리

마코가 처음 의견을 제안한 배경은 코드 이해의 어려움이었습니다.

이전 PR 논의 과정에서 생명주기가 같은 도메인 엔티티 간 CASCAADE로 묶어서 관리하는 것에 대해서는 의견이 합치되었습니다. 그리고 다음과 같은 내용에도 의견이 모여졌었습니다.

- Room, Progress, Content의 생명주기가 일치하는가?
    - Progress와 Content는 확실히 생명주기가 일치한다.
    - Room과 Progress/Content 는 생명주기가 일치한다고 보기 힘들다.

추가적으로 트랜잭션 범위를 최소화하기 위해 cascade를 가능한 작은 범위로 설정하는 것이 좋다는 내용도 있었습니다. 하지만 팀적으로 이를 확실하게 결론 짓기에는 팀원들 모두 적절한 경험이 없었죠.

논의 과정에서 결국 서비스에 트랜잭션 스크립트로 작성된 일련의 로직들을 전부 room에 응집시켜 사용할 것인지, 아니면 서비스로 꺼내서 피쳐별로 분리해서 사용할 것인지 확실하게 결정은 안났었습니다. 그러나 현실적인 팀의 리소스를 기반으로 판단했을 때 일단은 현상유지하는 것으로 결정했었습니다.

아직 못해본 것
- 실제 운영 데이터 베이스 상에서 성능차이? (네트워크를 거치며 발생하는 오버헤드)

<br/>

---

<br/>

## 개인적인 견해

일단 우리 서비스 코드에 애정을 갖고 더 나은 방향을 위해 생각들을 잘 정리해준 크루들에게 감사합니다. 덕분에 저도 이전에 생각하지 못했던 부분들에 대해 돌아볼 수 있었습니다. 다음은 개인적인 생각들을 정리해본 것입니다. 

- cascade 사용 기준에 대하여

이 부분에 대한 개인적인 의견은 마코가 제시해주신 기준에 좀 더 가깝습니다. cascade는 생명주기가 완전히 일치할 때 사용할 수도 있지만 소유하는 엔티티의 생명주기를 관리할 때도 사용한다고 합니다. PomodoroRoom에서만 PomodoroProgress를 소유한다는 것은 직관적으로 틀린말은 아닙니다.따라서 생명주기가 완전히 일치하지는 않지만 PomodoroRoom이 PomodoroProgress의 생명주기를 관리할 수 있다고 생각합니다. 그러나 반드시 그래야만 한다는 당위성이 있는 것은 아니에요. 그래서 우리 팀에서의 논의가 길어질 수 밖에 없지 않았나 싶습니다.

- 서비스에 구현된 비즈니스 로직 플로우

기존 PomodoroContentServiceV2의 모든 메서드에서 로직을 수행하기 전 progress를 반드시 조회합니다. 또한 다른 private 메서드들도 비즈니스 로직을 수행하기 전 progress의 상태를 확인하거나 progress를 통해 content를 찾아오는 경우가 많습니다. 이는 PomodoroContentServiceV2의 로직들이 progress 내부로 거의 캡슐화가 가능하다는 것을 암시합니다. 그러나 여기에서도 반드시 그래야만 한다는 당위성이 있지 않습니다. 

<br/>

아래는 팀에서 공통적으로 의견이 합치되었던 progress와 content 관련 서비스 계층 코드를 정리하며 생각해본 점들입니다.

```java
public Long register(GuestRegisterRequest request) {
    Member member = memberRepository.save(new Member(request.nickname()));
    PomodoroRoom pomodoroRoom = pomodoroRoomRepository.findById(request.studyId())
            .orElseThrow(RoomNotFoundException::new);
    Integer totalCycle = pomodoroRoom.getTotalCycle();

    PomodoroProgress pomodoroProgress = pomodoroProgressRepository.save(
            new PomodoroProgress(pomodoroRoom, member));
    for (int i = 1; i <= totalCycle; i++) {
        pomodoroContentRepository.save(new PomodoroContent(pomodoroProgress, i));
    }
    return member.getId();
}
```

해당 코드에서 불편한 부분

⇒ 비즈니스 로직을 수행하기 위해 pomodoroRoom의 totalCycle 상태값이 서비스 계층에 노출되고 있습니다. 또한 progress와 content는 생명주기가 동일한 엔티티임에도 서비스 계층에서 전부 따로 관리해주고 있습니다.

수정 이후

```java
// memberServiceV2
public Long register(GuestRegisterRequest request) {
    Member member = memberRepository.save(new Member(request.nickname()));
    PomodoroRoom pomodoroRoom = pomodoroRoomRepository.findById(request.studyId())
            .orElseThrow(RoomNotFoundException::new);
    pomodoroProgressRepository.save(new PomodoroProgress(pomodoroRoom, member));
    return member.getId();
}

// PomodoroProgress

public PomodoroProgress(PomodoroRoom pomodoroRoom, Member member) {
    this.pomodoroRoom = pomodoroRoom;
    this.member = member;
    this.currentCycle = 1;
    this.pomodoroStatus = PomodoroStatus.PLANNING;
    makeContentsByTotalCycle(pomodoroRoom.getTotalCycle());
}

private void makeContentsByTotalCycle(Integer totalCycle) {
    for (int i = 0; i < totalCycle; i++) {
        pomodoroContents.add(new PomodoroContent(this, i));
    }
}
```

팀에서 공통적으로 의견이 합치된 부분을 반영하기 위해 cascade를 통해 progress 내부에서 content를 생성하도록 변경함으로써 서비스 계층에 작성되었던 비즈니스 로직을 캡슐화했습니다.

하지만 pomodoroRoom에서 totalCycle을 꺼내 쓰는 건 여전히 남아 있네요. 이를 해결하기 위해서는 room에서 progress를 생성하도록 수정해야 합니다. 여기에서 다시 room에 cascade를 걸고 progress를 관리하도록 할 것인가에 대한 문제가 다시 떠오르게 되겠죠.

<br/>

---

<br/>

위에서도 언급했지만 cascade로 room에서 progress를 관리하도록 하는 것 자체는 room과 progress 엔티티 간 생명주기가 완전히 일치해야만 사용할 수 있는 것은 아니라고 생각합니다. PomodoroRoom에서만 PomodoroProgress를 소유할 것이기 때문에 progress에 대한 영속성을 room에서 관리하도록 위임할 수 있다고 생각해요.

다시 본론으로 돌아와서 얘기하자면 애그리거트를 비롯해 DDD용어를 사용하면서 논의가 필요 이상으로 깊어졌던 것이 없지않아 있었던 것 같습니다. 사실 저희 팀 논의의 본질은 우리 서비스 코드를 읽기 쉬운 코드로 개선해나가고자 했던 것인데 말이죠. 

현재 V1.0으로 릴리즈된 서비스 레이어 코드들을 살펴보면 객체 내부로 캡슐화할 수 있는 부분들이 그대로 남아있습니다. 하지만 API V2로 리팩토링을 거치고 난 뒤 불편할 정도로 가독성이 떨어진다고 느끼는 팀원들은 아마 없을 것이라 생각합니다. (코드를 읽는 능력이 많이 부족하다고 생각하는 저도 지금은 크게 불편함을 느끼지는 않으니까요)

개인적으로 객체 내부에 로직들이 응집성있게 작성되는 것을 선호하는 편이나 팀 논의 당시 기능 개발이 더 우선순위가 높았던 상황이었습니다. 또한 트랜잭션 범위 조절과 조회 시 성능 및 N+1문제를 다루는 것, 리팩토링된 프로젝트에 대한 팀원 간 동기화에 대한 부담등이 우리 팀에게 크게 다가왔었다고 생각합니다. 이러한 부분들을 현실적으로 고려해서 그 때 당시 우리팀의 최선을 선택한 결과였다고 말할 수 있을 것 같습니다. 

이후 언제 다시 해당 논의가 팀에서 이뤄져야 할까에 대한 기준을 정하지 못했던 기억이 납니다. 개인적으로, 만약 우리 서비스에서 제공하는 스터디 양식이 3개 4개가 추가되어 서비스 단에서 비즈니스 로직을 관리하는 것이 버겁다고 생각되는 순간이 온다면 그 때가 재논의 되어야 하는 시점이 아닐까 합니다. 저희가 현상유지의 근거로 들었던 문제점들이 해결하지 못할 수준의 문제들은 아니었다고 생각하거든요. 그 때가 된다면 지금 정리해뒀던 이 PR들을 다시 꺼내볼 수 있으면 좋겠네요!