### PR TITLE
[FE] OAuth 리다랙트 경로 상대 경로로 적용

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -9,15 +9,13 @@ import color from '@Styles/color';
 
 import { ROUTES_PATH } from '@Constants/routes';
 
-const REDIRECT_URI =
-  process.env.NODE_ENV === 'development'
-    ? 'http://localhost:3000/auth?provider=google'
-    : 'https://haru-study.com/auth?provider=google';
+const REDIRECT_URI = '/auth?provider=google';
 
 const Login = () => {
   const navigate = useNavigate();
+  const baseUri = `${window.location.protocol}//${window.location.host}`;
 
-  const googleOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${REDIRECT_URI}`;
+  const googleOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${baseUri}${REDIRECT_URI}`;
 
   return (
     <Layout>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -9,13 +9,13 @@ import color from '@Styles/color';
 
 import { ROUTES_PATH } from '@Constants/routes';
 
-const REDIRECT_URI = '/auth?provider=google';
+const REDIRECT_URI_PARAMETER = '/auth?provider=google';
 
 const Login = () => {
   const navigate = useNavigate();
   const baseUri = `${window.location.protocol}//${window.location.host}`;
 
-  const googleOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${baseUri}${REDIRECT_URI}`;
+  const googleOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${baseUri}${REDIRECT_URI_PARAMETER}`;
 
   return (
     <Layout>


### PR DESCRIPTION
## 관련 이슈
  closed #330 

## 구현 기능 및 변경 사항

```ts
const REDIRECT_URI = '/auth?provider=google';
const baseUri = `${window.location.protocol}//${window.location.host}`;
```

위와 같이 base uri를 가져와 oauth redirect uri 설정

## 스크린샷(선택)