### PR TITLE
[BE] 멤버가 스터디에 참여하지 않았다면 타인의 진행도를 볼 수 없게 수정 

### DIFF
--- a/backend/src/main/java/harustudy/backend/progress/service/PomodoroProgressService.java
+++ b/backend/src/main/java/harustudy/backend/progress/service/PomodoroProgressService.java
@@ -39,17 +39,24 @@ public class PomodoroProgressService {
         return PomodoroProgressResponse.from(pomodoroProgress);
     }
 
+    // TODO: 동적쿼리로 변경(memberId 유무에 따른 분기처리)
     public PomodoroProgressesResponse findPomodoroProgressWithFilter(
             AuthMember authMember, Long studyId, Long memberId
     ) {
         PomodoroRoom pomodoroRoom = pomodoroRoomRepository.findByIdIfExists(studyId);
-        // TODO: 동적쿼리로 변경(memberId 유무에 따른 분기처리)
+        validateEverParticipated(authMember, pomodoroRoom);
         if (Objects.isNull(memberId)) {
             return getPomodoroProgressesResponseWithoutMemberFilter(pomodoroRoom);
         }
         Member member = memberRepository.findByIdIfExists(memberId);
         validateIsSameMemberId(authMember, memberId);
         return getPomodoroProgressesResponseWithMemberFilter(pomodoroRoom, member);
+    }
+
+    private void validateEverParticipated(AuthMember authMember, PomodoroRoom pomodoroRoom) {
+        Member member = memberRepository.findByIdIfExists(authMember.id());
+        pomodoroProgressRepository.findByPomodoroRoomAndMember(pomodoroRoom, member)
+                .orElseThrow(AuthorizationException::new);
     }
 
     private PomodoroProgressesResponse getPomodoroProgressesResponseWithoutMemberFilter(


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #376 
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
검증로직의 부재로 현재 다른 스터디의 '기록 조회' 페이지가 열람이 가능한데, 멤버가 스터디에 참여하지 않았다면 타인의 진행도를 볼 수 없게 수정했습니다. 이에 따라 테스트도 몇개 추가했습니다.

## 스크린샷(선택)