### PR TITLE
[BE] 멤버 프로필 조회 시 불필요한 memberId를 담지 않도록 수정

### DIFF
--- a/backend/src/main/java/harustudy/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/harustudy/backend/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package harustudy.backend.member.controller;
 
 import harustudy.backend.auth.Authenticated;
 import harustudy.backend.auth.dto.AuthMember;
-import harustudy.backend.auth.exception.AuthorizationException;
 import harustudy.backend.common.SwaggerExceptionResponse;
 import harustudy.backend.member.dto.MemberResponse;
 import harustudy.backend.member.exception.MemberNotFoundException;
@@ -12,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "멤버 관련 기능")
@@ -23,16 +21,14 @@ public class MemberController {
     private final MemberService memberService;
 
     @SwaggerExceptionResponse({
-            MemberNotFoundException.class,
-            AuthorizationException.class
+            MemberNotFoundException.class
     })
-    @Operation(summary = "멤버 정보 조회")
-    @GetMapping("/api/members/{memberId}")
-    public ResponseEntity<MemberResponse> findMember(
-            @Authenticated AuthMember authMember,
-            @PathVariable Long memberId
+    @Operation(summary = "멤버 Oauth 프로필 정보 조회")
+    @GetMapping("/api/me")
+    public ResponseEntity<MemberResponse> findOauthProfile(
+            @Authenticated AuthMember authMember
     ) {
-        MemberResponse response = memberService.findMember(authMember, memberId);
+        MemberResponse response = memberService.findOauthProfile(authMember);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/harustudy/backend/member/service/MemberService.java
+++ b/backend/src/main/java/harustudy/backend/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package harustudy.backend.member.service;
 
 import harustudy.backend.auth.dto.AuthMember;
-import harustudy.backend.auth.exception.AuthorizationException;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.dto.MemberResponse;
 import harustudy.backend.member.exception.MemberNotFoundException;
@@ -17,15 +16,10 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public MemberResponse findMember(AuthMember authMember, Long memberId) {
+    public MemberResponse findOauthProfile(AuthMember authMember) {
         Member authorizedMember = memberRepository.findById(authMember.id())
                 .orElseThrow(MemberNotFoundException::new);
-        Member foundMember = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
 
-        if (authorizedMember.isDifferentMember(foundMember)) {
-            throw new AuthorizationException();
-        }
-        return MemberResponse.from(foundMember);
+        return MemberResponse.from(authorizedMember);
     }
 }

--- a/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
@@ -1,11 +1,9 @@
 package harustudy.backend.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import harustudy.backend.auth.dto.AuthMember;
-import harustudy.backend.auth.exception.AuthorizationException;
 import harustudy.backend.member.domain.LoginType;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.dto.MemberResponse;
@@ -52,7 +50,7 @@ class MemberServiceTest {
         AuthMember authMember = new AuthMember(member1.getId());
 
         // when
-        MemberResponse foundMember = memberService.findMember(authMember, member1.getId());
+        MemberResponse foundMember = memberService.findOauthProfile(authMember);
 
         //then
         assertSoftly(softly -> {
@@ -63,16 +61,5 @@ class MemberServiceTest {
             assertThat(foundMember.loginType()).isEqualTo(
                     member1.getLoginType().name().toLowerCase());
         });
-    }
-
-    @Test
-    void 인증된_멤버가_다른_멤버정보를_조회하면_인가_예외처리한다() {
-        // given
-        AuthMember authMember = new AuthMember(member1.getId());
-
-        // when, then
-        assertThatThrownBy(
-                () -> memberService.findMember(authMember, member2.getId())).isInstanceOf(
-                AuthorizationException.class);
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #383 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 멤버 프로필 조회 시 불필요한 memberId를 담지 않도록 수정