### PR TITLE
[BE] Member 영속화 시 필드 순서 조정 및 refresh token이 여러번 저장되는 문제 해결 

### DIFF
--- a/backend/src/main/java/harustudy/backend/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/harustudy/backend/auth/domain/RefreshToken.java
@@ -48,8 +48,9 @@ public class RefreshToken extends BaseTimeEntity {
         }
     }
 
-    public void updateUuidAndExpireDateTime(long expireLength) {
+    public RefreshToken updateUuidAndExpireDateTime(long expireLength) {
         this.uuid = UUID.randomUUID();
         this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);
+        return this;
     }
 }

--- a/backend/src/main/java/harustudy/backend/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/harustudy/backend/auth/domain/RefreshToken.java
@@ -48,9 +48,13 @@ public class RefreshToken extends BaseTimeEntity {
         }
     }
 
-    public RefreshToken updateUuidAndExpireDateTime(long expireLength) {
-        this.uuid = UUID.randomUUID();
+    public RefreshToken updateExpireDateTime(long expireLength) {
         this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);
         return this;
+    }
+
+    public void updateUuidAndExpireDateTime(long expireLength) {
+        this.uuid = UUID.randomUUID();
+        this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);
     }
 }

--- a/backend/src/main/java/harustudy/backend/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/harustudy/backend/auth/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package harustudy.backend.auth.repository;
 
 import harustudy.backend.auth.domain.RefreshToken;
+import harustudy.backend.member.domain.Member;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUuid(UUID refreshToken);
+
+    Optional<RefreshToken> findByMember(Member member);
 }

--- a/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
@@ -69,7 +69,7 @@ public class AuthService {
 
     private RefreshToken saveRefreshTokenOf(Member member) {
         RefreshToken refreshToken = refreshTokenRepository.findByMember(member)
-                .map(entity -> entity.updateUuidAndExpireDateTime(tokenConfig.refreshTokenExpireLength()))
+                .map(entity -> entity.updateExpireDateTime(tokenConfig.refreshTokenExpireLength()))
                 .orElseGet(() -> new RefreshToken(member, tokenConfig.refreshTokenExpireLength()));
         refreshTokenRepository.save(refreshToken);
         return refreshToken;

--- a/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
@@ -68,7 +68,9 @@ public class AuthService {
     }
 
     private RefreshToken saveRefreshTokenOf(Member member) {
-        RefreshToken refreshToken = new RefreshToken(member, tokenConfig.refreshTokenExpireLength());
+        RefreshToken refreshToken = refreshTokenRepository.findByMember(member)
+                .map(entity -> entity.updateUuidAndExpireDateTime(tokenConfig.refreshTokenExpireLength()))
+                .orElseGet(() -> new RefreshToken(member, tokenConfig.refreshTokenExpireLength()));
         refreshTokenRepository.save(refreshToken);
         return refreshToken;
     }

--- a/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
@@ -54,7 +54,7 @@ public class AuthService {
 
     private Member saveOrUpdateMember(String oauthProvider, UserInfo userInfo) {
         Member member = memberRepository.findByEmail(userInfo.email())
-                .map(entity -> entity.updateUserInfo(userInfo.email(), userInfo.name(), userInfo.imageUrl()))
+                .map(entity -> entity.updateUserInfo(userInfo.name(), userInfo.email(), userInfo.imageUrl()))
                 .orElseGet(() -> userInfo.toMember(LoginType.from(oauthProvider)));
         return memberRepository.save(member);
     }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- close #388 
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- Member 영속화 시 필드 저장 순서가 다른 문제를 해결한다.
- refresh token이 여러 번 저장되는 문제를 해결한다.

## 스크린샷(선택)