### PR TITLE
[BE] refresh 요청 시에도 쿠키 path '/' 으로 설정

### DIFF
--- a/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
@@ -60,6 +60,7 @@ public class AuthController {
         TokenResponse tokenResponse = authService.refresh(refreshToken);
         Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken().toString());
         cookie.setMaxAge(refreshTokenExpireLength.intValue());
+        cookie.setPath("/");
         httpServletResponse.addCookie(cookie);
         return ResponseEntity.ok(tokenResponse);
     }

--- a/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
@@ -38,6 +38,7 @@ public class AuthController {
         TokenResponse tokenResponse = authService.oauthLogin(request);
         Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken().toString());
         cookie.setMaxAge(refreshTokenExpireLength.intValue());
+        cookie.setPath("/");
         httpServletResponse.addCookie(cookie);
         return ResponseEntity.ok(tokenResponse);
     }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- close #395 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- `/api/refresh` 접근 시에도 refresh token cookie path 설정을 '/'로 한다.

## 스크린샷(선택)