### PR TITLE
[BE] 스터디에 학습 기록이 존재할 때 처음부터 진행하는 플로우에서 발생하는 문제

### DIFF
--- a/backend/src/main/java/harustudy/backend/progress/controller/PomodoroProgressController.java
+++ b/backend/src/main/java/harustudy/backend/progress/controller/PomodoroProgressController.java
@@ -19,7 +19,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "진행 관련 기능")
 @RequiredArgsConstructor
@@ -101,5 +107,15 @@ public class PomodoroProgressController {
         Long progressId = pomodoroProgressService.participateStudy(authMember, studyId, request);
         return ResponseEntity.created(
                 URI.create("/api/studies/" + studyId + "/progresses/" + progressId)).build();
+    }
+
+    @DeleteMapping("/api/studies/{studyId}/progresses/{progressId}")
+    public ResponseEntity<Void> delete(
+            @Authenticated AuthMember authMember,
+            @PathVariable Long studyId,
+            @PathVariable Long progressId
+    ) {
+        pomodoroProgressService.deleteProgress(authMember, studyId, progressId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/harustudy/backend/progress/domain/PomodoroProgress.java
+++ b/backend/src/main/java/harustudy/backend/progress/domain/PomodoroProgress.java
@@ -41,7 +41,7 @@ public class PomodoroProgress extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "pomodoroProgress", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "pomodoroProgress", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<PomodoroContent> pomodoroContents = new ArrayList<>();
 
     private String nickname;


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #408 
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- '/api/studies/{studyId}/progresses/{progressId}'를 통해 이미 존재하는 progress 및 content를 삭제하도록 한다.