### PR TITLE
[FE] 스터디 대기 인원 컴포넌트 UI 구현

### DIFF
--- a/frontend/src/components/waiting/StudyWaitingMembers/StudyWaitingMembers.tsx
+++ b/frontend/src/components/waiting/StudyWaitingMembers/StudyWaitingMembers.tsx
@@ -1,0 +1,56 @@
+import { css, styled } from 'styled-components';
+
+import Typography from '@Components/common/Typography/Typography';
+
+import color from '@Styles/color';
+
+type Props = {
+  waitingMembers: string[];
+};
+
+const StudyWaitingMembers = ({ waitingMembers }: Props) => {
+  return (
+    <Layout>
+      <Typography variant="p1">현재 참여한 스터디원</Typography>
+      <MembersFiled>
+        {waitingMembers.map((member, index) => (
+          <Typography key={index} variant="p2">
+            {member}
+          </Typography>
+        ))}
+      </MembersFiled>
+      <Typography
+        variant="p3"
+        $style={css`
+          align-self: center;
+          color: ${color.neutral[300]};
+        `}
+      >
+        스터디원들이 참여할 때까지 기다려주세요.
+      </Typography>
+    </Layout>
+  );
+};
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const MembersFiled = styled.div`
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  justify-items: center;
+  align-items: center;
+  gap: 30px;
+
+  width: 100%;
+  height: 100%;
+  padding: 50px 60px;
+
+  border-radius: 7px;
+  border: 1px solid ${color.neutral[200]};
+`;
+
+export default StudyWaitingMembers;

--- a/frontend/src/components/waiting/StudyWaitingMembers/StudyWaitingMemebers.stories.tsx
+++ b/frontend/src/components/waiting/StudyWaitingMembers/StudyWaitingMemebers.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import StudyWaitingMembers from './StudyWaitingMembers';
+
+type Story = StoryObj<typeof StudyWaitingMembers>;
+
+/**
+ * `StudyWaitingMembers` 컴포넌트는 어떤 스터디원이 들어왔는지 보여주는 컴포넌트입니다.
+ */
+const meta: Meta<typeof StudyWaitingMembers> = {
+  title: 'WAITING/StudyWaitingMembers',
+  component: StudyWaitingMembers,
+};
+
+export default meta;
+
+/**
+ * `OneRow`는 멤버가 6명일때 한줄이되는 `StudyWaitingMembers` 스토리입니다.
+ */
+export const OneRow: Story = {
+  args: {
+    waitingMembers: ['노아', '룩소', '엽토', '테오', '마코', '히이로'],
+  },
+};
+
+/**
+ * `TwoRow`는 멤버가 12명일때 두줄이되는 `StudyWaitingMembers` 스토리입니다.
+ */
+export const TwoRow: Story = {
+  args: {
+    waitingMembers: ['노아', '룩소', '엽토', '테오', '마코', '히이로', '모디', '왼손', '솔라', '준', '구구', '공원'],
+  },
+};


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #467 
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- StudyWaitingMembers 컴포넌트 구현
- StudyWaitingMembers 스토리북 작성

## 스크린샷(선택)
<img width="1122" alt="스크린샷 2023-09-03 오후 9 07 01" src="https://github.com/woowacourse-teams/2023-haru-study/assets/78894403/8cb8ce17-3de9-4deb-9d61-56bbfc3ece4a">
