### PR TITLE
[BE] OSIV 전역 설정 끄기

### DIFF
--- a/backend/src/main/resources/application-develop.yml
+++ b/backend/src/main/resources/application-develop.yml
@@ -5,6 +5,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
 
   flyway:
     enabled: false

--- a/backend/src/main/resources/application-production.yml
+++ b/backend/src/main/resources/application-production.yml
@@ -5,6 +5,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
 
   flyway:
     enabled: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
         ddl-auto: create-drop
         format_sql: true
     show-sql: true
+    open-in-view: false
 
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #493
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 현재 Service 레이어 외부에서 영속성 컨텍스트를 활용할 일이 없으므로 전역으로 OSIV를 사용하지 않게 바꿨습니다.
- 변경 후 Transactional 외부에서 영속성 컨텍스트에 의한 변경 감지가 일어나지 않게 됩니다.
- 변경 후 DB 커넥션을 더 짧게 사용하게 됩니다.

## 스크린샷(선택)
AS-IS
<img width="1192" alt="image" src="https://github.com/woowacourse-teams/2023-haru-study/assets/77962265/556a50a4-b71f-4ea9-96b6-eef0ce9972c2">
TO-BE
기존에 사용하던 OSIV로 인한 WARN 로그가 뜨지 않게 됩니다