### PR TITLE
[FE] MemberInfoProvider 로직 수정 및 useFetch, useMutation 옵션 추가

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -38,7 +38,7 @@
     "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-misused-promises": "off",
-    "@typescript-eslint/no-throw-literal": false,
+    "@typescript-eslint/no-throw-literal": "off",
     "import/no-unresolved": "off",
     "import/order": [
       "error",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
@@ -16,9 +17,11 @@ const App = () => {
       <GlobalStyles />
       <ModalProvider>
         <GlobalErrorBoundary fallback={ErrorFallback}>
-          <MemberInfoProvider>
-            <Outlet />
-          </MemberInfoProvider>
+          <Suspense fallback={<div>로딩 중...</div>}>
+            <MemberInfoProvider>
+              <Outlet />
+            </MemberInfoProvider>
+          </Suspense>
         </GlobalErrorBoundary>
       </ModalProvider>
     </ThemeProvider>

--- a/frontend/src/components/progress/hooks/useStudyBoard.ts
+++ b/frontend/src/components/progress/hooks/useStudyBoard.ts
@@ -13,7 +13,7 @@ const useStudyBoard = () => {
   const [error, setError] = useState<Error>();
 
   const { studyId } = useParams();
-  const { data: memberInfo } = useMemberInfo();
+  const memberInfo = useMemberInfo();
 
   const fetchStudyMetaData = useCallback(async () => {
     try {

--- a/frontend/src/contexts/StudyProgressProvider.tsx
+++ b/frontend/src/contexts/StudyProgressProvider.tsx
@@ -21,7 +21,7 @@ const StudyProgressActionContext = createContext<StudyProgressAction | null>(nul
 const StudyProgressProvider = ({ children }: PropsWithChildren) => {
   const navigate = useNavigate();
   const { studyId } = useParams();
-  const { data: memberInfo } = useMemberInfo();
+  const memberInfo = useMemberInfo();
 
   const [studyInfo, setStudyInfo] = useState<StudyInfo | null>(null);
   const [progressInfo, setProgressInfo] = useState<ProgressInfo | null>(null);

--- a/frontend/src/hooks/api/useFetch.ts
+++ b/frontend/src/hooks/api/useFetch.ts
@@ -40,7 +40,7 @@ const useFetch = <T>(
   const fetch = useCallback(() => {
     setStatus('pending');
     setPromise(request().then(resolvePromise, rejectPromise));
-  }, [rejectPromise, request, resolvePromise]);
+  }, []);
 
   useEffect(() => {
     if (enabled) {

--- a/frontend/src/hooks/api/useFetch.ts
+++ b/frontend/src/hooks/api/useFetch.ts
@@ -4,7 +4,7 @@ type Status = 'pending' | 'fulfilled' | 'error';
 
 type Options = {
   suspense?: boolean;
-  enable?: boolean;
+  enabled?: boolean;
 
   onSuccess?: <T>(result: T) => void;
   onError?: (error: Error) => void;
@@ -12,7 +12,7 @@ type Options = {
 
 const useFetch = <T>(
   request: () => Promise<T>,
-  { suspense = true, enable = true, onSuccess, onError }: Options = {},
+  { suspense = true, enabled = true, onSuccess, onError }: Options = {},
 ) => {
   const [promise, setPromise] = useState<Promise<void> | null>(null);
   const [status, setStatus] = useState<Status>('pending');
@@ -43,10 +43,10 @@ const useFetch = <T>(
   }, [rejectPromise, request, resolvePromise]);
 
   useEffect(() => {
-    if (enable) {
+    if (enabled) {
       fetch();
     }
-  }, [enable, fetch]);
+  }, [enabled, fetch]);
 
   const clearResult = () => setResult(null);
 

--- a/frontend/src/hooks/api/useFetch.ts
+++ b/frontend/src/hooks/api/useFetch.ts
@@ -4,28 +4,51 @@ type Status = 'pending' | 'fulfilled' | 'error';
 
 type Options = {
   suspense?: boolean;
+  enable?: boolean;
+
+  onSuccess?: <T>(result: T) => void;
+  onError?: (error: Error) => void;
 };
 
-const useFetch = <T>(request: () => Promise<T>, { suspense = true }: Options = {}) => {
-  const [promise, setPromise] = useState<Promise<void>>();
+const useFetch = <T>(
+  request: () => Promise<T>,
+  { suspense = true, enable = true, onSuccess, onError }: Options = {},
+) => {
+  const [promise, setPromise] = useState<Promise<void> | null>(null);
   const [status, setStatus] = useState<Status>('pending');
-  const [result, setResult] = useState<T>();
+  const [result, setResult] = useState<T | null>(null);
   const [error, setError] = useState<Error>();
 
-  const resolvePromise = useCallback((result: T) => {
-    setStatus('fulfilled');
-    setResult(result);
-  }, []);
+  const resolvePromise = useCallback(
+    (result: T) => {
+      setStatus('fulfilled');
+      setResult(result);
+      onSuccess?.(result);
+    },
+    [onSuccess],
+  );
 
-  const rejectPromise = useCallback((error: Error) => {
-    setStatus('error');
-    setError(error);
-  }, []);
+  const rejectPromise = useCallback(
+    (error: Error) => {
+      setStatus('error');
+      setError(error);
+      onError?.(error);
+    },
+    [onError],
+  );
 
-  useEffect(() => {
+  const fetch = useCallback(() => {
     setStatus('pending');
     setPromise(request().then(resolvePromise, rejectPromise));
-  }, []);
+  }, [rejectPromise, request, resolvePromise]);
+
+  useEffect(() => {
+    if (enable) {
+      fetch();
+    }
+  }, [enable, fetch]);
+
+  const clearResult = () => setResult(null);
 
   if (suspense && status === 'pending' && promise) {
     throw promise;
@@ -34,7 +57,7 @@ const useFetch = <T>(request: () => Promise<T>, { suspense = true }: Options = {
     throw error;
   }
 
-  return { result, isLoading: status === 'pending', error: error };
+  return { result, isLoading: status === 'pending', error: error, clearResult, refetch: fetch };
 };
 
 export default useFetch;

--- a/frontend/src/hooks/api/useMutation.ts
+++ b/frontend/src/hooks/api/useMutation.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 
-const useMutation = <T>(request: () => Promise<T>) => {
+type Options = {
+  onSuccess?: <T>(result: T) => void;
+  onError?: (error: Error) => void;
+};
+
+const useMutation = <T>(request: () => Promise<T>, { onSuccess, onError }: Options = {}) => {
   const [result, setResult] = useState<T | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown | null>(null);
@@ -11,9 +16,12 @@ const useMutation = <T>(request: () => Promise<T>) => {
     try {
       const result = await request();
       setResult(result);
+      onSuccess?.(result);
       return result;
     } catch (reason) {
+      if (!(reason instanceof Error)) throw reason;
       setError(reason);
+      onError?.(reason);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## 관련 이슈
#510과 연관된 이슈이지만 Auth로직은 아직 안되어있어서 closed는 안하겠습니다.

## 구현 기능 및 변경 사항
- useFetch 옵션(enabled, onSuccess, onError) 추가
- useMutation 옵션(onSuccess, onError) 추가
- MemberInfoProvider 로직 변경

## useFetch enabled옵션
useFetch의 enabled 옵션을 추가했습니다. MemberInfo도 MemberInfo인데, 이 옵션 추가도 리팩토링에 매우 중요할 것 같아서 PR을 빠르게 올립니다.
이 옵션은 useFetch를 순차적으로 실행 할 수 있게 도와줍니다. enabled가 false면 fetch를 실행 안하고 있다가, true로 바뀌면 fetch를 실행해요.

다음과 같이 사용할 수 있습니다.
```jsx
const memberInfo = useMemberInfo(); // memberInfo의 타입은 MemberInfo | null
const { ... } = useFetch(() => {requestFunc()}, {enabled: !!memberInfo});
```
이렇게 사용하면 memberInfo가 null일 때는 fetch가 되지 않다가, memberInfo 데이터가 들어오면 그제서야 fetch 실행을 합니다. 이렇게 하면 데이터 순서 보장을 할 수 있겠죠?

## 기타
바뀐 MemberInfo와 useFetch가 얼른 올라가야 추후 코드 병합하기도 좋을 것 같아 일단 MemberInfo만 우선적으로 올립니다.
지금은 MemberInfoProvider가 잘 작동하는지는 모르겠어요.. 일단 반영해보고 에러가 난다면 추후 수정해보시죠.