### PR TITLE
[FE] 로그인 페이지(Auth) 요청 순서 보장하지 못하는 버그

### DIFF
--- a/frontend/src/api/httpInstance.ts
+++ b/frontend/src/api/httpInstance.ts
@@ -16,8 +16,6 @@ const refreshAndRefetch = async <T extends object>(response: HttpResponse<T>) =>
     data: { accessToken },
   } = await http.post<{ accessToken: string }>('/api/auth/refresh');
 
-  console.log(accessToken);
-
   tokenStorage.setAccessToken(accessToken);
 
   return http.request<T>(response.url, response.config);

--- a/frontend/src/contexts/MemberInfoProvider.tsx
+++ b/frontend/src/contexts/MemberInfoProvider.tsx
@@ -7,6 +7,7 @@ import useFetch from '@Hooks/api/useFetch';
 import { ROUTES_PATH } from '@Constants/routes';
 
 import tokenStorage from '@Utils/tokenStorage';
+import url from '@Utils/url';
 
 import { requestGetMemberInfo } from '@Apis/index';
 
@@ -22,7 +23,10 @@ const MemberInfoContext = createContext<MemberInfo | null>(null);
 const MemberInfoActionContext = createContext<Actions | null>(null);
 
 const MemberInfoProvider = ({ children }: PropsWithChildren) => {
-  const { result, clearResult, refetch } = useFetch(() => requestGetMemberInfo(), { errorBoundary: false });
+  const { result, clearResult, refetch } = useFetch(() => requestGetMemberInfo(), {
+    errorBoundary: false,
+    enabled: url.getPathName() !== ROUTES_PATH.auth,
+  });
 
   const navigate = useNavigate();
 


### PR DESCRIPTION
## 관련 이슈
closed #538 

## 구현 기능 및 변경 사항
- Auth 페이지일 경우 초기 멤버 fetching 안하도록 수정

## 스크린샷(선택)