### PR TITLE
[FE] 모바일 환경에서의 구글 로그인 아이콘 위치 수정

### DIFF
--- a/frontend/src/components/landing/BugReportingLink/BugReportingLink.tsx
+++ b/frontend/src/components/landing/BugReportingLink/BugReportingLink.tsx
@@ -48,6 +48,10 @@ const GuideMessage = styled.p<GuideMessageProps>`
   `}
 
   transition: opacity 0.15s ease;
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const Link = styled.a`

--- a/frontend/src/components/landing/ChattingLink/ChattingLink.tsx
+++ b/frontend/src/components/landing/ChattingLink/ChattingLink.tsx
@@ -47,6 +47,10 @@ const GuideMessage = styled.p<GuideMessageProps>`
   `}
 
   transition: opacity 0.15s ease;
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const Link = styled.a`

--- a/frontend/src/components/landing/LoginModalContents/LoginModalContents.tsx
+++ b/frontend/src/components/landing/LoginModalContents/LoginModalContents.tsx
@@ -33,10 +33,10 @@ const LoginModalContents = () => {
       </Typography>
       <ButtonContainer>
         <a href={googleOAuthUrl}>
-          <GoogleButton variant="outlined">
+          <OAutLoginButton variant="outlined">
             <GoogleIcon />
-            <LoginText>구글로 로그인</LoginText>
-          </GoogleButton>
+            <span>구글로 로그인</span>
+          </OAutLoginButton>
         </a>
         <DividedContainer>
           <DividedLine></DividedLine>
@@ -70,30 +70,29 @@ const ButtonContainer = styled.div`
 
   width: 360px;
 
-  svg {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-
-    display: flex;
-    margin: auto 0;
-  }
-
   @media screen and (max-width: 768px) {
     width: 95%;
   }
 `;
 
-const GoogleButton = styled(Button)`
+const OAutLoginButton = styled(Button)`
+  position: relative;
+
   border-radius: 8px;
   border: 1px solid ${color.neutral[300]};
 
   color: ${color.black};
   font-size: 1.8rem;
-`;
 
-const LoginText = styled.span`
-  position: relative;
+  svg {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 32px;
+
+    display: flex;
+    margin: auto 0;
+  }
 `;
 
 const Emphasis = styled.span`


### PR DESCRIPTION
## 관련 이슈
  closed #547 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 모바일 환경에서의 구글 로그인 아이콘 위치 수정

## 스크린샷(선택)

<img width="568" alt="스크린샷 2023-09-21 오전 11 08 40" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/b126cdcf-1ffd-45a6-8078-acad9cf9ba5e">

<img width="421" alt="스크린샷 2023-09-21 오전 11 08 43" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/228180ec-1c36-4f99-95d4-3fbb8ffc271c">

<img width="422" alt="스크린샷 2023-09-21 오전 11 09 58" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/32947ce7-cad3-4c11-84d8-632017e75379">
