### PR TITLE
[BE] participant에서 content 생성 로직 분리

### DIFF
--- a/backend/src/main/java/harustudy/backend/participant/domain/Participant.java
+++ b/backend/src/main/java/harustudy/backend/participant/domain/Participant.java
@@ -57,7 +57,6 @@ public class Participant extends BaseTimeEntity {
         validateNicknameLength(nickname);
         Participant participant = new Participant(study, member, nickname, study.isEmptyParticipants());
         study.addParticipant(participant);
-        participant.generateContents(study.getTotalCycle());
         return participant;
     }
 
@@ -67,7 +66,7 @@ public class Participant extends BaseTimeEntity {
         }
     }
 
-    private void generateContents(int totalCycle) {
+    public void generateContents(int totalCycle) {
         for (int cycle = 1; cycle <= totalCycle; cycle++) {
             Content content = new Content(this, cycle);
             contents.add(content);

--- a/backend/src/main/java/harustudy/backend/participant/service/ParticipantService.java
+++ b/backend/src/main/java/harustudy/backend/participant/service/ParticipantService.java
@@ -114,6 +114,7 @@ public class ParticipantService {
         Study study = studyRepository.findByIdIfExists(studyId);
         validateIsWaiting(study);
         Participant participant = Participant.instantiateParticipantWithContents(study, member, request.nickname());
+        participant.generateContents(study.getTotalCycle());
         Participant saved = participantRepository.save(participant);
         return saved.getId();
     }

--- a/backend/src/test/java/harustudy/backend/content/repository/ContentRepositoryTest.java
+++ b/backend/src/test/java/harustudy/backend/content/repository/ContentRepositoryTest.java
@@ -1,6 +1,5 @@
 package harustudy.backend.content.repository;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import harustudy.backend.content.domain.Content;
@@ -11,6 +10,7 @@ import harustudy.backend.study.domain.Study;
 
 import java.util.Map;
 
+import harustudy.backend.testutils.EntityManagerUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -42,7 +42,7 @@ class ContentRepositoryTest {
         testEntityManager.persist(member);
         testEntityManager.persist(participant);
 
-        flushAndClearContext(testEntityManager);
+        EntityManagerUtil.flushAndClearContext(testEntityManager);
     }
 
     @Test
@@ -54,7 +54,7 @@ class ContentRepositoryTest {
         content.changePlan(plan);
         testEntityManager.persist(content);
 
-        flushAndClearContext(testEntityManager);
+        EntityManagerUtil.flushAndClearContext(testEntityManager);
 
         // when
         Content found = contentRepository.findById(content.getId())
@@ -77,7 +77,7 @@ class ContentRepositoryTest {
         content.changeRetrospect(retrospect);
         testEntityManager.persist(content);
 
-        flushAndClearContext(testEntityManager);
+        EntityManagerUtil.flushAndClearContext(testEntityManager);
 
         // when
         Content found = contentRepository.findById(content.getId())

--- a/backend/src/test/java/harustudy/backend/content/repository/ContentRepositoryTest.java
+++ b/backend/src/test/java/harustudy/backend/content/repository/ContentRepositoryTest.java
@@ -42,7 +42,7 @@ class ContentRepositoryTest {
         testEntityManager.persist(member);
         testEntityManager.persist(participant);
 
-        FLUSH_AND_CLEAR_CONTEXT(testEntityManager);
+        flushAndClearContext(testEntityManager);
     }
 
     @Test
@@ -54,7 +54,7 @@ class ContentRepositoryTest {
         content.changePlan(plan);
         testEntityManager.persist(content);
 
-        FLUSH_AND_CLEAR_CONTEXT(testEntityManager);
+        flushAndClearContext(testEntityManager);
 
         // when
         Content found = contentRepository.findById(content.getId())
@@ -77,7 +77,7 @@ class ContentRepositoryTest {
         content.changeRetrospect(retrospect);
         testEntityManager.persist(content);
 
-        FLUSH_AND_CLEAR_CONTEXT(testEntityManager);
+        flushAndClearContext(testEntityManager);
 
         // when
         Content found = contentRepository.findById(content.getId())

--- a/backend/src/test/java/harustudy/backend/content/repository/ContentRepositoryTest.java
+++ b/backend/src/test/java/harustudy/backend/content/repository/ContentRepositoryTest.java
@@ -1,5 +1,6 @@
 package harustudy.backend.content.repository;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import harustudy.backend.content.domain.Content;
@@ -9,6 +10,7 @@ import harustudy.backend.participant.domain.Participant;
 import harustudy.backend.study.domain.Study;
 
 import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -40,8 +42,7 @@ class ContentRepositoryTest {
         testEntityManager.persist(member);
         testEntityManager.persist(participant);
 
-        testEntityManager.flush();
-        testEntityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(testEntityManager);
     }
 
     @Test
@@ -53,8 +54,7 @@ class ContentRepositoryTest {
         content.changePlan(plan);
         testEntityManager.persist(content);
 
-        testEntityManager.flush();
-        testEntityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(testEntityManager);
 
         // when
         Content found = contentRepository.findById(content.getId())
@@ -77,8 +77,7 @@ class ContentRepositoryTest {
         content.changeRetrospect(retrospect);
         testEntityManager.persist(content);
 
-        testEntityManager.flush();
-        testEntityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(testEntityManager);
 
         // when
         Content found = contentRepository.findById(content.getId())

--- a/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
@@ -1,6 +1,6 @@
 package harustudy.backend.content.service;
 
-import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
+import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,6 +18,7 @@ import harustudy.backend.participant.exception.ParticipantNotFoundException;
 import harustudy.backend.participant.exception.StudyStepException;
 import harustudy.backend.study.domain.Study;
 import harustudy.backend.study.exception.StudyNotFoundException;
+import harustudy.backend.testutils.EntityManagerUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
@@ -59,7 +60,7 @@ class ContentServiceTest {
         entityManager.persist(participant);
         entityManager.persist(content);
 
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test
@@ -71,7 +72,7 @@ class ContentServiceTest {
         study.proceed();
 
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         WritePlanRequest request = new WritePlanRequest(participant.getId(),
                 Map.of("plan", "abc"));
@@ -88,7 +89,7 @@ class ContentServiceTest {
         study.proceed();
 
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         AuthMember authMember = new AuthMember(member.getId());
         WritePlanRequest request = new WritePlanRequest(participant.getId(),
@@ -140,7 +141,7 @@ class ContentServiceTest {
 
         entityManager.merge(content);
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         WriteRetrospectRequest request = new WriteRetrospectRequest(participant.getId(),
                 Map.of("retrospect", "abc"));
@@ -161,7 +162,7 @@ class ContentServiceTest {
         content.changeRetrospect(retrospect);
 
         entityManager.merge(content);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when
         ContentsResponse contentsResponse =
@@ -199,7 +200,7 @@ class ContentServiceTest {
         entityManager.merge(study);
         entityManager.merge(content);
         entityManager.persist(anotherContent);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when
         ContentsResponse contentsResponse = contentService.findContentsWithFilter(authMember,

--- a/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
@@ -1,5 +1,6 @@
 package harustudy.backend.content.service;
 
+import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,18 +51,15 @@ class ContentServiceTest {
         study = new Study("studyName", 1, 20);
         member = new Member("nickname", "email", "imageUrl", LoginType.GUEST);
         participant = Participant.instantiateParticipantWithContents(study, member, "nickname");
-        content = participant.getContents().get(0);
+
+        content = new Content(participant, 1);
 
         entityManager.persist(study);
         entityManager.persist(member);
         entityManager.persist(participant);
         entityManager.persist(content);
-        FLUSH_AND_CLEAR_CONTEXT();
-    }
 
-    void FLUSH_AND_CLEAR_CONTEXT() {
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test
@@ -71,7 +69,9 @@ class ContentServiceTest {
 
         study.proceed();
         study.proceed();
+
         entityManager.merge(study);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         WritePlanRequest request = new WritePlanRequest(participant.getId(),
                 Map.of("plan", "abc"));
@@ -86,7 +86,10 @@ class ContentServiceTest {
     void 계획_단계에서는_계획을_작성할_수_있다() {
         // given
         study.proceed();
+
         entityManager.merge(study);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+
         AuthMember authMember = new AuthMember(member.getId());
         WritePlanRequest request = new WritePlanRequest(participant.getId(),
                 Map.of("plan", "abc"));
@@ -137,7 +140,7 @@ class ContentServiceTest {
 
         entityManager.merge(content);
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         WriteRetrospectRequest request = new WriteRetrospectRequest(participant.getId(),
                 Map.of("retrospect", "abc"));
@@ -158,7 +161,7 @@ class ContentServiceTest {
         content.changeRetrospect(retrospect);
 
         entityManager.merge(content);
-        FLUSH_AND_CLEAR_CONTEXT();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when
         ContentsResponse contentsResponse =
@@ -196,7 +199,7 @@ class ContentServiceTest {
         entityManager.merge(study);
         entityManager.merge(content);
         entityManager.persist(anotherContent);
-        FLUSH_AND_CLEAR_CONTEXT();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when
         ContentsResponse contentsResponse = contentService.findContentsWithFilter(authMember,

--- a/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
@@ -1,6 +1,5 @@
 package harustudy.backend.content.service;
 
-import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/backend/src/test/java/harustudy/backend/integration/ContentIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ContentIntegrationTest.java
@@ -1,7 +1,6 @@
 package harustudy.backend.integration;
 
 
-import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/backend/src/test/java/harustudy/backend/integration/ContentIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ContentIntegrationTest.java
@@ -1,7 +1,7 @@
 package harustudy.backend.integration;
 
 
-import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
+import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -17,6 +17,8 @@ import harustudy.backend.study.domain.Study;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+
+import harustudy.backend.testutils.EntityManagerUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -48,7 +50,7 @@ public class ContentIntegrationTest extends IntegrationTest {
         entityManager.persist(participant);
         entityManager.persist(content);
 
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test
@@ -60,7 +62,7 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         study.proceed();
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when, then
         mockMvc.perform(
@@ -81,7 +83,7 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         entityManager.merge(study);
         entityManager.merge(content);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         WriteRetrospectRequest request = new WriteRetrospectRequest(participant.getId(),
                 Map.of("retrospect", "test"));
@@ -109,7 +111,7 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         entityManager.merge(study);
         entityManager.merge(content);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when
         MvcResult result = mockMvc.perform(
@@ -149,7 +151,7 @@ public class ContentIntegrationTest extends IntegrationTest {
         entityManager.merge(content);
         entityManager.merge(participant);
         entityManager.persist(anotherContent);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when
         MvcResult result = mockMvc.perform(

--- a/backend/src/test/java/harustudy/backend/integration/ContentIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ContentIntegrationTest.java
@@ -1,6 +1,7 @@
 package harustudy.backend.integration;
 
 
+import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -41,13 +42,13 @@ public class ContentIntegrationTest extends IntegrationTest {
         study = new Study("studyName", 2, 20);
         memberDto = createMember("member1");
         participant = Participant.instantiateParticipantWithContents(study, memberDto.member(), "nickname");
-        content = participant.getContents().get(0);
+        content = new Content(participant, 1);
 
         entityManager.persist(study);
         entityManager.persist(participant);
         entityManager.persist(content);
 
-        FLUSH_AND_CLEAR_CONTEXT();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test
@@ -59,6 +60,7 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         study.proceed();
         entityManager.merge(study);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when, then
         mockMvc.perform(
@@ -79,7 +81,7 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         entityManager.merge(study);
         entityManager.merge(content);
-        FLUSH_AND_CLEAR_CONTEXT();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         WriteRetrospectRequest request = new WriteRetrospectRequest(participant.getId(),
                 Map.of("retrospect", "test"));
@@ -107,7 +109,7 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         entityManager.merge(study);
         entityManager.merge(content);
-        FLUSH_AND_CLEAR_CONTEXT();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when
         MvcResult result = mockMvc.perform(
@@ -138,7 +140,7 @@ public class ContentIntegrationTest extends IntegrationTest {
         content.changePlan(plan);
         content.changeRetrospect(retrospect);
 
-        Content anotherContent = participant.getContents().get(1);
+        Content anotherContent = new Content(participant, 1);
         Map<String, String> anotherPlan = Map.of("plan", "test");
         Map<String, String> anotherRetrospect = Map.of("retrospect", "test");
         anotherContent.changePlan(anotherPlan);
@@ -146,8 +148,8 @@ public class ContentIntegrationTest extends IntegrationTest {
 
         entityManager.merge(content);
         entityManager.merge(participant);
-        entityManager.merge(anotherContent);
-        FLUSH_AND_CLEAR_CONTEXT();
+        entityManager.persist(anotherContent);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when
         MvcResult result = mockMvc.perform(

--- a/backend/src/test/java/harustudy/backend/integration/IntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/IntegrationTest.java
@@ -68,11 +68,6 @@ class IntegrationTest {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
     }
 
-    void FLUSH_AND_CLEAR_CONTEXT() {
-        entityManager.flush();
-        entityManager.clear();
-    }
-
     protected void setMockMvc() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
     }

--- a/backend/src/test/java/harustudy/backend/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/MemberIntegrationTest.java
@@ -1,5 +1,6 @@
 package harustudy.backend.integration;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -8,6 +9,7 @@ import harustudy.backend.member.dto.MemberResponse;
 import harustudy.backend.participant.domain.Participant;
 import harustudy.backend.study.domain.Study;
 import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -40,6 +42,7 @@ class MemberIntegrationTest extends IntegrationTest {
         entityManager.persist(study);
         entityManager.persist(participant1);
         entityManager.persist(participant2);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/MemberIntegrationTest.java
@@ -42,7 +42,7 @@ class MemberIntegrationTest extends IntegrationTest {
         entityManager.persist(study);
         entityManager.persist(participant1);
         entityManager.persist(participant2);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/MemberIntegrationTest.java
@@ -1,6 +1,5 @@
 package harustudy.backend.integration;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,6 +9,7 @@ import harustudy.backend.participant.domain.Participant;
 import harustudy.backend.study.domain.Study;
 import java.nio.charset.StandardCharsets;
 
+import harustudy.backend.testutils.EntityManagerUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -42,7 +42,7 @@ class MemberIntegrationTest extends IntegrationTest {
         entityManager.persist(study);
         entityManager.persist(participant1);
         entityManager.persist(participant2);
-        flushAndClearContext(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/ParticipantIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ParticipantIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -33,9 +34,7 @@ class ParticipantIntegrationTest extends IntegrationTest {
 
         entityManager.persist(study);
         entityManager.persist(participant);
-
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/ParticipantIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ParticipantIntegrationTest.java
@@ -34,7 +34,7 @@ class ParticipantIntegrationTest extends IntegrationTest {
 
         entityManager.persist(study);
         entityManager.persist(participant);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/ParticipantIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ParticipantIntegrationTest.java
@@ -3,6 +3,7 @@ package harustudy.backend.integration;
 import harustudy.backend.participant.domain.Participant;
 import harustudy.backend.participant.dto.ParticipantResponse;
 import harustudy.backend.study.domain.Study;
+import harustudy.backend.testutils.EntityManagerUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -11,7 +12,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -34,7 +34,7 @@ class ParticipantIntegrationTest extends IntegrationTest {
 
         entityManager.persist(study);
         entityManager.persist(participant);
-        flushAndClearContext(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/PollingIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/PollingIntegrationTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,9 +48,7 @@ class PollingIntegrationTest extends IntegrationTest {
         entityManager.persist(participant1);
         entityManager.persist(participant2);
         entityManager.persist(participant3);
-
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/PollingIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/PollingIntegrationTest.java
@@ -4,6 +4,7 @@ import harustudy.backend.participant.domain.Participant;
 import harustudy.backend.participant.dto.ParticipantResponse;
 import harustudy.backend.study.domain.Study;
 import harustudy.backend.polling.dto.WaitingResponse;
+import harustudy.backend.testutils.EntityManagerUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -16,7 +17,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -48,7 +48,7 @@ class PollingIntegrationTest extends IntegrationTest {
         entityManager.persist(participant1);
         entityManager.persist(participant2);
         entityManager.persist(participant3);
-        flushAndClearContext(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/PollingIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/PollingIntegrationTest.java
@@ -48,7 +48,7 @@ class PollingIntegrationTest extends IntegrationTest {
         entityManager.persist(participant1);
         entityManager.persist(participant2);
         entityManager.persist(participant3);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/StudyIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/StudyIntegrationTest.java
@@ -1,5 +1,6 @@
 package harustudy.backend.integration;
 
+import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -52,9 +53,7 @@ class StudyIntegrationTest extends IntegrationTest {
         entityManager.persist(study1);
         entityManager.persist(study2);
         entityManager.persist(participant1);
-
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/StudyIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/StudyIntegrationTest.java
@@ -1,6 +1,6 @@
 package harustudy.backend.integration;
 
-import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
+import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -15,6 +15,7 @@ import harustudy.backend.study.domain.Study;
 import harustudy.backend.study.dto.CreateStudyRequest;
 import harustudy.backend.study.dto.StudiesResponse;
 import harustudy.backend.study.dto.StudyResponse;
+import harustudy.backend.testutils.EntityManagerUtil;
 import jakarta.persistence.EntityManager;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -53,7 +54,7 @@ class StudyIntegrationTest extends IntegrationTest {
         entityManager.persist(study1);
         entityManager.persist(study2);
         entityManager.persist(participant1);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/integration/StudyIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/StudyIntegrationTest.java
@@ -1,6 +1,5 @@
 package harustudy.backend.integration;
 
-import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/backend/src/test/java/harustudy/backend/integration/ViewIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ViewIntegrationTest.java
@@ -1,6 +1,5 @@
 package harustudy.backend.integration;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -13,6 +12,7 @@ import harustudy.backend.polling.dto.ProgressResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+import harustudy.backend.testutils.EntityManagerUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -45,7 +45,7 @@ public class ViewIntegrationTest extends IntegrationTest {
         entityManager.persist(study);
         entityManager.persist(participant1);
         entityManager.persist(participant2);
-        flushAndClearContext(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/harustudy/backend/integration/ViewIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ViewIntegrationTest.java
@@ -1,5 +1,6 @@
 package harustudy.backend.integration;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,6 +12,7 @@ import harustudy.backend.study.domain.Study;
 import harustudy.backend.polling.dto.ProgressResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -43,6 +45,7 @@ public class ViewIntegrationTest extends IntegrationTest {
         entityManager.persist(study);
         entityManager.persist(participant1);
         entityManager.persist(participant2);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/harustudy/backend/integration/ViewIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/ViewIntegrationTest.java
@@ -45,7 +45,7 @@ public class ViewIntegrationTest extends IntegrationTest {
         entityManager.persist(study);
         entityManager.persist(participant1);
         entityManager.persist(participant2);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        flushAndClearContext(entityManager);
     }
 
     @ParameterizedTest

--- a/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package harustudy.backend.member.service;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -40,8 +41,7 @@ class MemberServiceTest {
 
         entityManager.persist(member1);
         entityManager.persist(member2);
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
@@ -41,7 +41,7 @@ class MemberServiceTest {
 
         entityManager.persist(member1);
         entityManager.persist(member2);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/member/service/MemberServiceTest.java
@@ -1,6 +1,5 @@
 package harustudy.backend.member.service;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -8,6 +7,7 @@ import harustudy.backend.auth.dto.AuthMember;
 import harustudy.backend.member.domain.LoginType;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.dto.MemberResponse;
+import harustudy.backend.testutils.EntityManagerUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +41,7 @@ class MemberServiceTest {
 
         entityManager.persist(member1);
         entityManager.persist(member2);
-        flushAndClearContext(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/harustudy/backend/participant/service/ParticipantServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participant/service/ParticipantServiceTest.java
@@ -12,6 +12,7 @@ import harustudy.backend.participantcode.domain.CodeGenerationStrategy;
 import harustudy.backend.participantcode.domain.ParticipantCode;
 import harustudy.backend.study.domain.Study;
 import harustudy.backend.study.exception.StudyAlreadyStartedException;
+import harustudy.backend.testutils.EntityManagerUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.assertj.core.api.AssertionsForClassTypes;
@@ -25,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
+import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -65,7 +66,7 @@ class ParticipantServiceTest {
         entityManager.persist(participantCode2);
         entityManager.persist(member1);
         entityManager.persist(member2);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test
@@ -75,7 +76,7 @@ class ParticipantServiceTest {
         ParticipateStudyRequest request = new ParticipateStudyRequest(member1.getId(), "nick");
         Study study = entityManager.merge(study1);
         study.proceed();
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when, then
         assertThatThrownBy(
@@ -92,7 +93,7 @@ class ParticipantServiceTest {
 
         entityManager.persist(participant);
         entityManager.persist(anotherParticipant);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         List<ParticipantResponse> responses = Stream.of(participant, anotherParticipant)
                 .map(ParticipantResponse::from)
@@ -129,7 +130,7 @@ class ParticipantServiceTest {
 
         entityManager.persist(participant);
         entityManager.persist(anotherParticipant);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         ParticipantsResponse expected = ParticipantsResponse.from(List.of(
                 ParticipantResponse.from(participant)
@@ -151,7 +152,7 @@ class ParticipantServiceTest {
         AuthMember authMember = new AuthMember(member2.getId());
 
         entityManager.persist(participant);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when, then
         assertThatThrownBy(() ->
@@ -168,7 +169,7 @@ class ParticipantServiceTest {
 
         entityManager.persist(participant1);
         entityManager.persist(participant2);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when, then
         assertThatThrownBy(() ->

--- a/backend/src/test/java/harustudy/backend/participant/service/ParticipantServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participant/service/ParticipantServiceTest.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/backend/src/test/java/harustudy/backend/participant/service/ParticipantServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participant/service/ParticipantServiceTest.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -64,9 +65,7 @@ class ParticipantServiceTest {
         entityManager.persist(participantCode2);
         entityManager.persist(member1);
         entityManager.persist(member2);
-
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
     }
 
     @Test
@@ -76,7 +75,7 @@ class ParticipantServiceTest {
         ParticipateStudyRequest request = new ParticipateStudyRequest(member1.getId(), "nick");
         Study study = entityManager.merge(study1);
         study.proceed();
-        entityManager.flush();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when, then
         assertThatThrownBy(
@@ -93,6 +92,7 @@ class ParticipantServiceTest {
 
         entityManager.persist(participant);
         entityManager.persist(anotherParticipant);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         List<ParticipantResponse> responses = Stream.of(participant, anotherParticipant)
                 .map(ParticipantResponse::from)
@@ -129,6 +129,7 @@ class ParticipantServiceTest {
 
         entityManager.persist(participant);
         entityManager.persist(anotherParticipant);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         ParticipantsResponse expected = ParticipantsResponse.from(List.of(
                 ParticipantResponse.from(participant)
@@ -150,6 +151,7 @@ class ParticipantServiceTest {
         AuthMember authMember = new AuthMember(member2.getId());
 
         entityManager.persist(participant);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when, then
         assertThatThrownBy(() ->
@@ -166,6 +168,7 @@ class ParticipantServiceTest {
 
         entityManager.persist(participant1);
         entityManager.persist(participant2);
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when, then
         assertThatThrownBy(() ->

--- a/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
@@ -34,7 +34,7 @@ class ParticipantCodeServiceTest {
         ParticipantCode participantCode = new ParticipantCode(study, new CodeGenerationStrategy());
         entityManager.persist(study);
         entityManager.persist(participantCode);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        flushAndClearContext(entityManager);
 
         // when
         ParticipantCodeResponse result = participantCodeService.findParticipantCodeByStudyId(

--- a/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import static harustudy.backend.testutils.EntityManagerUtil.*;
+
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @Transactional
@@ -32,8 +34,7 @@ class ParticipantCodeServiceTest {
         ParticipantCode participantCode = new ParticipantCode(study, new CodeGenerationStrategy());
         entityManager.persist(study);
         entityManager.persist(participantCode);
-        entityManager.flush();
-        entityManager.clear();
+        FLUSH_AND_CLEAR_CONTEXT(entityManager);
 
         // when
         ParticipantCodeResponse result = participantCodeService.findParticipantCodeByStudyId(

--- a/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/participantcode/service/ParticipantCodeServiceTest.java
@@ -4,6 +4,7 @@ import harustudy.backend.participantcode.domain.CodeGenerationStrategy;
 import harustudy.backend.participantcode.domain.ParticipantCode;
 import harustudy.backend.participantcode.dto.ParticipantCodeResponse;
 import harustudy.backend.study.domain.Study;
+import harustudy.backend.testutils.EntityManagerUtil;
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -13,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import static harustudy.backend.testutils.EntityManagerUtil.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -34,7 +34,7 @@ class ParticipantCodeServiceTest {
         ParticipantCode participantCode = new ParticipantCode(study, new CodeGenerationStrategy());
         entityManager.persist(study);
         entityManager.persist(participantCode);
-        flushAndClearContext(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when
         ParticipantCodeResponse result = participantCodeService.findParticipantCodeByStudyId(

--- a/backend/src/test/java/harustudy/backend/polling/service/PollingServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/polling/service/PollingServiceTest.java
@@ -10,6 +10,7 @@ import harustudy.backend.polling.dto.SubmitterResponse;
 import harustudy.backend.polling.dto.SubmittersResponse;
 import harustudy.backend.polling.dto.WaitingResponse;
 import harustudy.backend.polling.exception.CannotSeeSubmittersException;
+import harustudy.backend.testutils.EntityManagerUtil;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -23,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static harustudy.backend.testutils.EntityManagerUtil.FLUSH_AND_CLEAR_CONTEXT;
+import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -77,7 +78,7 @@ class PollingServiceTest {
         entityManager.persist(content1);
         entityManager.persist(content2);
         entityManager.persist(content3);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
     }
 
     @Test
@@ -95,7 +96,7 @@ class PollingServiceTest {
 
         entityManager.merge(study);
         entityManager.merge(content1);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         SubmittersResponse expected = new SubmittersResponse(List.of(
                 new SubmitterResponse("parti1", true),
@@ -118,7 +119,7 @@ class PollingServiceTest {
         study.proceed();
 
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when, then
         assertThatThrownBy(() -> pollingService.findSubmitters(study.getId()))
@@ -136,7 +137,7 @@ class PollingServiceTest {
         entityManager.merge(study);
         entityManager.merge(content1);
         entityManager.merge(content2);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when
         SubmittersResponse submitters = pollingService.findSubmitters(study.getId());
@@ -161,7 +162,7 @@ class PollingServiceTest {
         study.proceed();
 
         entityManager.merge(study);
-        FLUSH_AND_CLEAR_CONTEXT(entityManager);
+        EntityManagerUtil.flushAndClearContext(entityManager);
 
         // when, then
         assertThatThrownBy(() -> pollingService.findSubmitters(study.getId()))

--- a/backend/src/test/java/harustudy/backend/polling/service/PollingServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/polling/service/PollingServiceTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static harustudy.backend.testutils.EntityManagerUtil.flushAndClearContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/backend/src/test/java/harustudy/backend/testutils/EntityManagerUtil.java
+++ b/backend/src/test/java/harustudy/backend/testutils/EntityManagerUtil.java
@@ -5,12 +5,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 public class EntityManagerUtil {
 
-    public static void FLUSH_AND_CLEAR_CONTEXT(EntityManager entityManager) {
+    public static void flushAndClearContext(EntityManager entityManager) {
         entityManager.flush();
         entityManager.clear();
     }
 
-    public static void FLUSH_AND_CLEAR_CONTEXT(TestEntityManager entityManager) {
+    public static void flushAndClearContext(TestEntityManager entityManager) {
         entityManager.flush();
         entityManager.clear();
     }

--- a/backend/src/test/java/harustudy/backend/testutils/EntityManagerUtil.java
+++ b/backend/src/test/java/harustudy/backend/testutils/EntityManagerUtil.java
@@ -1,0 +1,17 @@
+package harustudy.backend.testutils;
+
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+public class EntityManagerUtil {
+
+    public static void FLUSH_AND_CLEAR_CONTEXT(EntityManager entityManager) {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    public static void FLUSH_AND_CLEAR_CONTEXT(TestEntityManager entityManager) {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed: #591 
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- [x] participant에서 content 생성 로직 분리
- [x] test에서 flush & clear 로직 통일
    - 기존에 flush & clear하는 메서드를 테스트 내에서 따로 만들어줘서 중복이 많았어서 EntityManagerUtil로 분리했습니다