### PR TITLE
[BE] 로그아웃 기능 및 인증 관련 정비

### DIFF
--- a/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
@@ -87,17 +87,19 @@ public class AuthController {
         String refreshToken = extractRefreshTokenFromCookie(request);
         authService.deleteStringifiedRefreshToken(refreshToken);
 
-        deleteCookies(request, response);
+        deleteRefreshTokenFromCookie(request, response);
 
         return ResponseEntity.ok().build();
     }
 
-    private void deleteCookies(HttpServletRequest request, HttpServletResponse response) {
+    private void deleteRefreshTokenFromCookie(HttpServletRequest request, HttpServletResponse response) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                cookie.setMaxAge(0);
-                response.addCookie(cookie);
+                if (cookie.getName().equals("refreshToken")) {
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
             }
         }
     }

--- a/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
@@ -65,6 +65,8 @@ public class AuthController {
         Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken().toString());
         cookie.setMaxAge(refreshTokenExpireLength.intValue() / 1000);
         cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         return cookie;
     }
 

--- a/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/harustudy/backend/auth/controller/AuthController.java
@@ -51,13 +51,13 @@ public class AuthController {
     @Operation(summary = "access 토큰, refresh 토큰 갱신")
     @PostMapping("/api/auth/refresh")
     public ResponseEntity<TokenResponse> refresh(
-            HttpServletRequest httpServletRequest,
-            HttpServletResponse httpServletResponse
+            HttpServletRequest request,
+            HttpServletResponse response
     ) {
-        String refreshToken = extractRefreshTokenFromCookie(httpServletRequest);
+        String refreshToken = extractRefreshTokenFromCookie(request);
         TokenResponse tokenResponse = authService.refresh(refreshToken);
         Cookie cookie = setUpRefreshTokenCookie(tokenResponse);
-        httpServletResponse.addCookie(cookie);
+        response.addCookie(cookie);
         return ResponseEntity.ok(tokenResponse);
     }
 
@@ -70,11 +70,35 @@ public class AuthController {
         return cookie;
     }
 
-    private String extractRefreshTokenFromCookie(HttpServletRequest httpServletRequest) {
-        return Arrays.stream(httpServletRequest.getCookies())
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        return Arrays.stream(request.getCookies())
                 .filter(cookie -> cookie.getName().equals("refreshToken"))
                 .map(Cookie::getValue)
                 .findAny()
                 .orElseThrow(RefreshTokenNotExistsException::new);
+    }
+
+    @Operation(summary = "로그아웃, access & refresh 토큰 삭제")
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<Void> logout(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        authService.deleteStringifiedRefreshToken(refreshToken);
+
+        deleteCookies(request, response);
+
+        return ResponseEntity.ok().build();
+    }
+
+    private void deleteCookies(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                cookie.setMaxAge(0);
+                response.addCookie(cookie);
+            }
+        }
     }
 }

--- a/backend/src/main/java/harustudy/backend/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/harustudy/backend/auth/repository/RefreshTokenRepository.java
@@ -16,5 +16,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     @Modifying
     @Query("delete from RefreshToken r where r.uuid = :uuid")
-    void deleteTokenWithoutContextUpdate(UUID uuid);
+    void deleteByUuidWithoutContextUpdate(UUID uuid);
 }

--- a/backend/src/main/java/harustudy/backend/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/harustudy/backend/auth/repository/RefreshTokenRepository.java
@@ -5,10 +5,16 @@ import harustudy.backend.member.domain.Member;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUuid(UUID refreshToken);
 
     Optional<RefreshToken> findByMember(Member member);
+
+    @Modifying
+    @Query("delete from RefreshToken r where r.uuid = :uuid")
+    void deleteTokenWithoutContextUpdate(UUID uuid);
 }

--- a/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
@@ -96,6 +96,6 @@ public class AuthService {
 
     public void deleteStringifiedRefreshToken(String refreshToken) {
         UUID uuid = UUID.fromString(refreshToken);
-        refreshTokenRepository.deleteTokenWithoutContextUpdate(uuid);
+        refreshTokenRepository.deleteByUuidWithoutContextUpdate(uuid);
     }
 }

--- a/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
@@ -93,4 +93,9 @@ public class AuthService {
     public String parseMemberId(String accessToken) {
         return jwtTokenProvider.parseSubject(accessToken, tokenConfig.secretKey());
     }
+
+    public void deleteStringifiedRefreshToken(String refreshToken) {
+        UUID uuid = UUID.fromString(refreshToken);
+        refreshTokenRepository.deleteTokenWithoutContextUpdate(uuid);
+    }
 }

--- a/backend/src/main/java/harustudy/backend/auth/service/OauthLoginFacade.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/OauthLoginFacade.java
@@ -11,9 +11,11 @@ import harustudy.backend.auth.util.OauthUserInfoExtractor;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
+@Transactional
 public class OauthLoginFacade {
 
     private final OauthProperties oauthProperties;
@@ -21,6 +23,7 @@ public class OauthLoginFacade {
     private final AuthService authService;
 
     public TokenResponse oauthLogin(OauthLoginRequest request) {
+        // TODO: 에러 핸들링
         UserInfo userInfo = requestUserInfo(request.oauthProvider(), request.code());
         return authService.userLogin(request, userInfo);
     }

--- a/backend/src/main/java/harustudy/backend/auth/service/OauthLoginFacade.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/OauthLoginFacade.java
@@ -21,7 +21,6 @@ public class OauthLoginFacade {
     private final AuthService authService;
 
     public TokenResponse oauthLogin(OauthLoginRequest request) {
-        // TODO: webClient 관련 에러 핸들링
         UserInfo userInfo = requestUserInfo(request.oauthProvider(), request.code());
         return authService.userLogin(request, userInfo);
     }

--- a/backend/src/main/java/harustudy/backend/auth/service/OauthLoginFacade.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/OauthLoginFacade.java
@@ -11,11 +11,9 @@ import harustudy.backend.auth.util.OauthUserInfoExtractor;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
-@Transactional
 public class OauthLoginFacade {
 
     private final OauthProperties oauthProperties;
@@ -23,7 +21,7 @@ public class OauthLoginFacade {
     private final AuthService authService;
 
     public TokenResponse oauthLogin(OauthLoginRequest request) {
-        // TODO: 에러 핸들링
+        // TODO: webClient 관련 에러 핸들링
         UserInfo userInfo = requestUserInfo(request.oauthProvider(), request.code());
         return authService.userLogin(request, userInfo);
     }

--- a/backend/src/test/java/harustudy/backend/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/auth/service/AuthServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -144,5 +146,27 @@ class AuthServiceTest {
         // when, then
         assertThatThrownBy(() -> authService.validateAccessToken(accessToken)).isInstanceOf(
                 InvalidAccessTokenException.class);
+    }
+
+    @Test
+    void 갱신_토큰을_삭제한다() {
+        // given
+        Member member = new Member("test", "test@test.com", "test.png", LoginType.GOOGLE);
+        RefreshToken refreshToken = new RefreshToken(member,
+                tokenConfig.refreshTokenExpireLength());
+
+        entityManager.persist(member);
+        entityManager.persist(refreshToken);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        String stringifiedUUID = refreshToken.getUuid().toString();
+
+        // then
+        assertNotNull(entityManager.find(RefreshToken.class, refreshToken.getId()));
+        authService.deleteStringifiedRefreshToken(stringifiedUUID);
+        entityManager.clear();
+        assertNull(entityManager.find(RefreshToken.class, refreshToken.getId()));
     }
 }

--- a/backend/src/test/java/harustudy/backend/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/auth/service/AuthServiceTest.java
@@ -120,7 +120,7 @@ class AuthServiceTest {
     }
 
     @Test
-    void 유효한_액세스_토큰의_유효성_검사_시_예외를_반환한다() {
+    void 유효한_액세스_토큰의_유효성_검사_시_예외를_반환하지_않는다() {
         // given
         Long memberId = 1L;
         String accessToken = jwtTokenProvider.builder()

--- a/backend/src/test/java/harustudy/backend/integration/AuthIntegrationTest.java
+++ b/backend/src/test/java/harustudy/backend/integration/AuthIntegrationTest.java
@@ -2,15 +2,19 @@ package harustudy.backend.integration;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import harustudy.backend.auth.domain.RefreshToken;
 import harustudy.backend.auth.dto.TokenResponse;
+import harustudy.backend.member.domain.Member;
 import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MvcResult;
@@ -60,7 +64,7 @@ class AuthIntegrationTest extends IntegrationTest {
     @Test
     void 액세스_토큰을_갱신한다() throws Exception {
         // given
-        MemberDto memberDto1 = createMember("member1");
+        MemberDto memberDto = createMember("member1");
 
         // access token을 재발급 하더라도 Date는 초 단위의 시간 정보를 담은 액세스 토큰을 생성하기 때문에
         // 같은 access token이 만들어지는 문제가 있어서 갱신된다는 것을 검증하기 위해 사용
@@ -70,7 +74,7 @@ class AuthIntegrationTest extends IntegrationTest {
         MvcResult result = mockMvc.perform(
                         post("/api/auth/refresh")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .cookie(memberDto1.cookie()))
+                                .cookie(memberDto.cookie()))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -81,10 +85,26 @@ class AuthIntegrationTest extends IntegrationTest {
 
         assertSoftly(softly -> {
             softly.assertThat(response.accessToken()).isNotNull();
-            softly.assertThat(response.accessToken()).isNotEqualTo(memberDto1.accessToken());
+            softly.assertThat(response.accessToken()).isNotEqualTo(memberDto.accessToken());
             softly.assertThat(refreshToken).isNotNull();
             softly.assertThat(refreshToken.getName()).isEqualTo("refreshToken");
-            softly.assertThat(refreshToken.getValue()).isNotEqualTo(memberDto1.cookie().getValue());
+            softly.assertThat(refreshToken.getValue()).isNotEqualTo(memberDto.cookie().getValue());
         });
+    }
+
+    @Test
+    void 로그아웃한다() throws Exception {
+        // given
+        MemberDto memberDto = createMember("member1");
+        Member member = generateAndSaveMemberNamedWith("member1");
+        RefreshToken refreshToken = generateAndSaveRefreshTokenOf(member);
+
+        // when, then
+        mockMvc.perform(post("/api/auth/logout")
+                        .cookie(new Cookie("refreshToken", refreshToken.getUuid().toString()))
+                        .header(HttpHeaders.AUTHORIZATION, memberDto.createAuthorizationHeader()))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("refreshToken", 0))
+                .andReturn();
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #607 
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- [x] 로그아웃 API 호출 시 RefreshToken을 포함한 쿠키를 제거한다
- [x] 로그아웃 API 호출 시 RefreshToken을 DB에서 삭제한다
- [x] XSS 공격을 대비하여 cookie의 httpOnly 설정을 켠다
- [x] https에서만 사용되도록 cookie의 secure 설정을 켠다
- [x] ~~로그인 과정에서 누락된 스프링 트랜잭션 설정을 추가한다~~
