### PR TITLE
[FE] 목록 조회 totalPages 오류 수정 및 EmptyMemberRecord 개선

### DIFF
--- a/frontend/src/components/common/Footer/Footer.tsx
+++ b/frontend/src/components/common/Footer/Footer.tsx
@@ -1,5 +1,5 @@
-import color from '@Styles/color';
 import { styled } from 'styled-components';
+
 import Typography from '../Typography/Typography';
 
 const URL = {
@@ -17,12 +17,12 @@ const Footer = () => {
         Copyright © 2023 하루스터디 - All rights reserved.
       </Typography>
       <LinkContainer>
-        <a target="_blank" href={URL.github}>
+        <a target="_blank" href={URL.github} rel="noreferrer">
           <Typography variant="p3" fontSize="12px">
             Github
           </Typography>
         </a>
-        <a target="_blank" href={URL.feedback}>
+        <a target="_blank" href={URL.feedback} rel="noreferrer">
           <Typography variant="p3" fontSize="12px">
             사용자 피드백
           </Typography>

--- a/frontend/src/components/record/hooks/useMemberListRecord.ts
+++ b/frontend/src/components/record/hooks/useMemberListRecord.ts
@@ -36,7 +36,7 @@ const useMemberListRecord = ({ memberId }: Props) => {
 
     setMemberRecords(studyRecords || []);
     if (totalPagesNumber === 1 || pageInfo.totalPages !== pageInfo.totalPages + 1)
-      setTotalPagesNumber(pageInfo.totalPages + 1);
+      setTotalPagesNumber(pageInfo.totalPages);
   }, [result]);
 
   return { memberRecords, isLoading, totalPagesNumber, shiftPage, currentPageNumber: page };

--- a/frontend/src/components/record/member/period/EmptyMemberRecord/EmptyMemberRecord.tsx
+++ b/frontend/src/components/record/member/period/EmptyMemberRecord/EmptyMemberRecord.tsx
@@ -21,7 +21,7 @@ const EmptyMemberRecord = () => {
           text-align: center;
         `}
       >
-        아직 완료한 스터디가 없어요.
+        완료한 스터디가 없어요.
         <br />
         스터디를 시작해 보세요.
       </Typography>

--- a/frontend/src/components/record/member/period/EmptyMemberRecord/EmptyMemberRecord.tsx
+++ b/frontend/src/components/record/member/period/EmptyMemberRecord/EmptyMemberRecord.tsx
@@ -23,17 +23,12 @@ const EmptyMemberRecord = () => {
       >
         아직 완료한 스터디가 없어요.
         <br />
-        스터디를 개설하거나 참여하여 스터디를 진행해보세요.
+        스터디를 시작해 보세요.
       </Typography>
       <ButtonContainer>
-        <Link to={ROUTES_PATH.create}>
+        <Link to={ROUTES_PATH.mode}>
           <Button variant="primary" size="small" $block={false}>
-            스터디 개설하기
-          </Button>
-        </Link>
-        <Link to={ROUTES_PATH.participation}>
-          <Button variant="outlined" size="small" $block={false}>
-            스터디 참여하기
+            스터디 시작하기
           </Button>
         </Link>
       </ButtonContainer>
@@ -49,15 +44,36 @@ const Layout = styled.div`
   align-items: center;
   gap: 20px;
 
-  padding-top: 80px;
+  padding-top: 40px;
 
   svg {
     width: 80px;
     height: 80px;
+  }
+
+  @media screen and (max-width: 768px) {
+    gap: 20px;
+
+    padding-top: 20px;
+
+    p {
+      font-size: 1.6rem;
+    }
+
+    svg {
+      width: 60px;
+      height: 60px;
+    }
   }
 `;
 
 const ButtonContainer = styled.div`
   display: flex;
   gap: 20px;
+
+  @media screen and (max-width: 768px) {
+    button {
+      font-size: 1.6rem;
+    }
+  }
 `;

--- a/frontend/src/components/record/member/period/MemberRecordPeriod/MemberRecordPeriod.tsx
+++ b/frontend/src/components/record/member/period/MemberRecordPeriod/MemberRecordPeriod.tsx
@@ -23,12 +23,14 @@ const MemberRecordPeriod = ({ memberId }: Props) => {
   return (
     <Layout>
       <PeriodSelectionBar />
-      <PaginationButton
-        totalPagesNumber={totalPagesNumber}
-        currentPageNumber={currentPageNumber}
-        isLoading={isLoading}
-        shiftPage={shiftPage}
-      />
+      {totalPagesNumber !== 0 && (
+        <PaginationButton
+          totalPagesNumber={totalPagesNumber}
+          currentPageNumber={currentPageNumber}
+          isLoading={isLoading}
+          shiftPage={shiftPage}
+        />
+      )}
       <MemberRecordPeriodList memberRecords={memberRecords} isLoading={isLoading} />
       {memberRecords && memberRecords.length > 3 && (
         <PaginationButton

--- a/frontend/src/mocks/handlers/queryHandler.ts
+++ b/frontend/src/mocks/handlers/queryHandler.ts
@@ -10,6 +10,7 @@ import {
   STUDY_LIST_8,
   STUDY_LIST_9,
   STUDY_LIST_ALL,
+  STUDY_LIST_EMPTY,
   STUDY_LIST_ONE_MONTH,
   STUDY_LIST_THREE_MONTH,
   STUDY_LIST_WEEK,
@@ -50,6 +51,11 @@ export const queryHandler = [
       ? {
           studyRecords: STUDY_LIST_ONE_MONTH.studyRecords.slice(20 * page, 20 * (page + 1)),
           pageInfo: STUDY_LIST_ONE_MONTH.pageInfo,
+        }
+      : startDate === format.date(new Date('2023-07-01'), '-')
+      ? {
+          studyRecords: STUDY_LIST_EMPTY.studyRecords,
+          pageInfo: STUDY_LIST_EMPTY.pageInfo,
         }
       : {
           studyRecords: STUDY_LIST_WEEK.studyRecords.slice(20 * page, 20 * (page + 1)),

--- a/frontend/src/mocks/mockData.ts
+++ b/frontend/src/mocks/mockData.ts
@@ -195,7 +195,7 @@ export const STUDY_LIST_ALL: {
     };
   }),
   pageInfo: {
-    totalPages: 10,
+    totalPages: 11,
   },
 };
 
@@ -222,7 +222,7 @@ export const STUDY_LIST_THREE_MONTH: {
     };
   }),
   pageInfo: {
-    totalPages: 2,
+    totalPages: 3,
   },
 };
 
@@ -249,7 +249,26 @@ export const STUDY_LIST_ONE_MONTH: {
     };
   }),
   pageInfo: {
-    totalPages: 1,
+    totalPages: 2,
+  },
+};
+
+// 1개월 목록 조회
+export const STUDY_LIST_EMPTY: {
+  studyRecords: {
+    studyId: string;
+    name: string;
+    timePerCycle: number;
+    totalCycle: number;
+    createdDate: string;
+  }[];
+  pageInfo: {
+    totalPages: number;
+  };
+} = {
+  studyRecords: [],
+  pageInfo: {
+    totalPages: 0,
   },
 };
 


### PR DESCRIPTION
## 관련 이슈
  closed #628 

## 구현 기능 및 변경 사항

- 기록 목록 조회 전체 페이지 버그 수정: totalPages은 1부터 시작합니다. 이를 생각하지 못하고 로직을 작성하여 수정합니다.
- 기록이 없는 경우 Pagination 버튼 제거
- 기록이 없는 경우 보여지는 EmptyMemberRecord 개선
    - 문구를 "완료한 스터디가 없어요. 스터디를 시작해 보세요."로 수정 -> 괜찮은 문구 있으면 추천해주세요.
    - 기존 스터디 개설하기, 스터디 참여하기 버튼을 스터디 시작하기 버튼으로 대체함. 버튼을 통해 `/mode`로 이동
    - 반응형 추가

## 스크린샷(선택)
<img width="472" alt="스크린샷 2023-10-06 오후 8 49 35" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/49bff3ad-ebab-4d78-aa3f-89d8cf108d71">

<img width="1327" alt="스크린샷 2023-10-06 오후 8 49 45" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/9fef6fed-b071-4cf4-a444-9516f13b90e5">

