### PR TITLE
[FE] 카카오 로그인 기능 추가

### DIFF
--- a/frontend/src/components/landing/LoginModalContents/LoginModalContents.tsx
+++ b/frontend/src/components/landing/LoginModalContents/LoginModalContents.tsx
@@ -9,6 +9,7 @@ import color from '@Styles/color';
 
 import { ROUTES_PATH } from '@Constants/routes';
 
+import ChatIcon from '@Assets/icons/ChatIcon';
 import GoogleIcon from '@Assets/icons/GoogleIcon';
 
 const REDIRECT_URI_PARAMETER = '/auth?provider=google';
@@ -33,10 +34,16 @@ const LoginModalContents = () => {
       </Typography>
       <ButtonContainer>
         <a href={googleOAuthUrl}>
-          <OAutLoginButton variant="outlined">
+          <GoogleOAuthLoginButton variant="outlined">
             <GoogleIcon />
             <span>구글로 로그인</span>
-          </OAutLoginButton>
+          </GoogleOAuthLoginButton>
+        </a>
+        <a href={googleOAuthUrl}>
+          <KakaoOAuthLoginButton variant="outlined">
+            <ChatIcon color={color.black} />
+            <span>카카오로 로그인</span>
+          </KakaoOAuthLoginButton>
         </a>
         <DividedContainer>
           <DividedLine></DividedLine>
@@ -79,9 +86,7 @@ const OAutLoginButton = styled(Button)`
   position: relative;
 
   border-radius: 8px;
-  border: 1px solid ${color.neutral[300]};
 
-  color: ${color.black};
   font-size: 1.8rem;
 
   svg {
@@ -90,8 +95,30 @@ const OAutLoginButton = styled(Button)`
     bottom: 0;
     left: 32px;
 
+    width: 30px;
+    height: 30px;
+
     display: flex;
     margin: auto 0;
+  }
+`;
+
+const GoogleOAuthLoginButton = styled(OAutLoginButton)`
+  border: 1px solid ${color.neutral[300]};
+
+  color: ${color.black};
+`;
+
+const KakaoOAuthLoginButton = styled(OAutLoginButton)`
+  border: none;
+
+  color: rgba(0, 0, 0, 0.85);
+  background-color: ${color.brand.kakao};
+
+  &:hover {
+    &:enabled {
+      background-color: ${color.brand.kakao};
+    }
   }
 `;
 

--- a/frontend/src/components/landing/LoginModalContents/LoginModalContents.tsx
+++ b/frontend/src/components/landing/LoginModalContents/LoginModalContents.tsx
@@ -12,12 +12,14 @@ import { ROUTES_PATH } from '@Constants/routes';
 import ChatIcon from '@Assets/icons/ChatIcon';
 import GoogleIcon from '@Assets/icons/GoogleIcon';
 
-const REDIRECT_URI_PARAMETER = '/auth?provider=google';
+const GOOGLE_AUTH_REDIRECT_URI_PARAMETER = '/auth?provider=google';
+const KAKAO_AUTH_REDIRECT_URI_PARAMETER = '/auth?provider=kakao';
 
 const LoginModalContents = () => {
   const baseUri = `${window.location.protocol}//${window.location.host}`;
 
-  const googleOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${baseUri}${REDIRECT_URI_PARAMETER}`;
+  const googleOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${baseUri}${GOOGLE_AUTH_REDIRECT_URI_PARAMETER}`;
+  const kakaoOAUthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&redirect_uri=${baseUri}${KAKAO_AUTH_REDIRECT_URI_PARAMETER}&response_type=code`;
 
   return (
     <Layout>
@@ -39,7 +41,7 @@ const LoginModalContents = () => {
             <span>구글로 로그인</span>
           </GoogleOAuthLoginButton>
         </a>
-        <a href={googleOAuthUrl}>
+        <a href={kakaoOAUthUrl}>
           <KakaoOAuthLoginButton variant="outlined">
             <ChatIcon color={color.black} />
             <span>카카오로 로그인</span>

--- a/frontend/src/styles/color.ts
+++ b/frontend/src/styles/color.ts
@@ -3,7 +3,7 @@ const color = {
   black: '#000000',
   yellow: '#fcd34d',
   brand: {
-    kakao: '#ffe812',
+    kakao: '#FEE500',
   },
   red: {
     200: '#cf8080',

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,3 +1,3 @@
-export type OAuthProvider = 'google';
+export type OAuthProvider = 'google' | 'kakao';
 
 export type AuthProvider = OAuthProvider | 'guest';


### PR DESCRIPTION
## 관련 이슈
  closed #632 

## 구현 기능 및 변경 사항
- 카카오 로그인 기능 추가

## 스크린샷(선택)

카카오 말풍선 svg을 찾지 못해 기존 사용하고 있던, chat icon으로 사용합니다. 추후에 좋은 svg, png가 있다면 업데이트할게요. 카카오 개발자 센터에서 제공하는 로그인 관련 이미지는 각각 분리되어 있지 않고 모두 하나의 이미지로 만들어져 있어 사용하기에 불편함이 있습니다. 혹시 이에 대해 좋은 팁이 있다면 알려주세요! 😁

<img width="670" alt="스크린샷 2023-10-11 오후 3 46 12" src="https://github.com/woowacourse-teams/2023-haru-study/assets/57981252/8900294c-48ab-414d-8b74-1df1e629876c">


