### PR TITLE
[BE] 소셜 로그인 로직 개선

### DIFF
--- a/backend/src/main/java/harustudy/backend/auth/domain/oauth/GoogleOauthClient.java
+++ b/backend/src/main/java/harustudy/backend/auth/domain/oauth/GoogleOauthClient.java
@@ -2,15 +2,14 @@ package harustudy.backend.auth.domain.oauth;
 
 import harustudy.backend.auth.dto.OauthTokenResponse;
 import harustudy.backend.auth.util.OauthWebClient;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
@@ -35,6 +34,7 @@ public class GoogleOauthClient implements OauthClient {
     @Value("${oauth2.oauth-properties.google.user-info-uri}")
     private String userInfoUri;
 
+    @Override
     public OauthTokenResponse requestOauthToken(String code) {
         return oauthWebClient.requestOauthToken(tokenUri, setupFormData(code));
     }
@@ -49,12 +49,13 @@ public class GoogleOauthClient implements OauthClient {
         return formData;
     }
 
+    @Override
     public Map<String, Object> requestOauthUserInfo(String accessToken) {
         return oauthWebClient.requestOauthUserInfo(userInfoUri, accessToken);
     }
 
     @Override
-    public String getProviderName() {
-        return PROVIDER_NAME;
+    public boolean supports(String oauthClient) {
+        return oauthClient.equals(PROVIDER_NAME);
     }
 }

--- a/backend/src/main/java/harustudy/backend/auth/domain/oauth/KakaoOauthClient.java
+++ b/backend/src/main/java/harustudy/backend/auth/domain/oauth/KakaoOauthClient.java
@@ -56,7 +56,7 @@ public class KakaoOauthClient implements OauthClient {
     }
 
     @Override
-    public String getProviderName() {
-        return PROVIDER_NAME;
+    public boolean supports(String oauthClient) {
+        return oauthClient.equals(PROVIDER_NAME);
     }
 }

--- a/backend/src/main/java/harustudy/backend/auth/domain/oauth/OauthClient.java
+++ b/backend/src/main/java/harustudy/backend/auth/domain/oauth/OauthClient.java
@@ -10,5 +10,5 @@ public interface OauthClient {
 
     Map<String, Object> requestOauthUserInfo(String accessToken);
 
-    String getProviderName();
+    boolean supports(String oauthProvider);
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #648
## 구현 기능 및 변경 사항
AS-IS
``` java
@Component
public class OauthClients {

    private final Map<String, OauthClient> clientMappings;

    public OauthClients(List<OauthClient> clientMappings) {
        this.clientMappings = clientMappings.stream()
                .collect(Collectors.toMap(OauthClient::getProviderName, Function.identity()));
    }
```
일급 컬렉션인 OauthClients가 생성 시점에 필드로 가지고 있을 구현체들의 ProviderName을 getter를 사용해 참조합니다

TO-BE
``` java
@RequiredArgsConstructor
@Component
public class OauthClients {

    private final List<OauthClient> oauthClients;

```
일급 컬렉션은 리스트로 구현체들을 자동 주입받게 하고
OAuthClient 인터페이스에 getter를 넣어두는 대신 boolean을 반환하는 supports()를 만들어 특정 provider를 처리 가능한지 외부에서 물어보도록 변형합니다

성능적으로는 map을 만들어두는 것이 좋으나 비용 차이가 크지 않고 객체지향적인 코드는 후자여서 제안해봅니다