### PR TITLE
[BE] 목표 작성 없이 방장이 강제로 다음 단계로 넘어가면 studyStep이 적절하지 않다고 표시되는 문제 수정

### DIFF
--- a/backend/src/main/java/harustudy/backend/content/service/ContentService.java
+++ b/backend/src/main/java/harustudy/backend/content/service/ContentService.java
@@ -140,8 +140,6 @@ public class ContentService {
         validateStudyIsRetrospect(study);
 
         Content recentContent = findContentWithSameCycle(study, participant);
-        validateIsPlanFilled(recentContent);
-
         recentContent.changeRetrospect(request.retrospect());
     }
 
@@ -153,12 +151,6 @@ public class ContentService {
 
     private void validateStudyIsRetrospect(Study study) {
         if (!study.isStep(Step.RETROSPECT)) {
-            throw new StudyStepException();
-        }
-    }
-
-    private void validateIsPlanFilled(Content recentContent) {
-        if (!recentContent.isPlanWritten()) {
             throw new StudyStepException();
         }
     }

--- a/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
@@ -3,6 +3,7 @@ package harustudy.backend.content.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import harustudy.backend.auth.dto.AuthMember;
 import harustudy.backend.content.domain.Content;
@@ -102,17 +103,23 @@ class ContentServiceTest {
     }
 
     @Test
-    void 계획이_작성되어_있지_않은_경우_회고를_작성하려_하면_예외를_던진다() {
+    void 계획이_작성되어_있지_않은_경우에도_회고를_작성할_수_있다() {
         // given
+        study.proceed();
+        study.proceed();
+        study.proceed();
+
+        entityManager.merge(study);
+        EntityManagerUtil.flushAndClearContext(entityManager);
+
         AuthMember authMember = new AuthMember(member.getId());
         WriteRetrospectRequest request = new WriteRetrospectRequest(participant.getId(),
                 Map.of("retrospect", "abc"));
 
         // when, then
-        assertThatThrownBy(
-                () -> contentService.writeRetrospect(authMember, study.getId(),
-                        request))
-                .isInstanceOf(StudyStepException.class);
+        assertDoesNotThrow(
+                () -> contentService.writeRetrospect(authMember, study.getId(), request)
+        );
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #659

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 한 사이클 내에서 계획 단계를 작성하지 않았어도 회고 단계를 작성할 수 있도록 수정

## 스크린샷(선택)