### PR TITLE
[FE] 스터디 동기화 기능 버그 수정 및 추가 기능 구현

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -116,7 +116,7 @@ export const requestPostRegisterParticipants = (nickname: string, studyId: strin
     body: JSON.stringify({ memberId, nickname }),
   });
 
-export const requestDeleteParticipant = (studyId: string, participantId: number) =>
+export const requestDeleteParticipant = (studyId: string, participantId: string) =>
   http.delete(`/api/studies/${studyId}/participants/${participantId}`);
 
 export const requestGetParticipantCode = async (studyId: string) => {

--- a/frontend/src/components/lobby/ParticipantList/ParticipantList.tsx
+++ b/frontend/src/components/lobby/ParticipantList/ParticipantList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { css, styled } from 'styled-components';

--- a/frontend/src/components/lobby/hooks/useStudyLobby.ts
+++ b/frontend/src/components/lobby/hooks/useStudyLobby.ts
@@ -14,7 +14,7 @@ const useStudyLobby = (studyId: string, memberId: string) => {
 
   const { mutate: startStudy, isLoading: isStarting } = useMutation(() => requestPostNextStep(studyId));
   const { mutate: exitStudy, isLoading: isExiting } = useMutation(() =>
-    requestDeleteParticipant(studyId, Number(participantInfo?.participantId)),
+    requestDeleteParticipant(studyId, participantInfo!.participantId),
   );
 
   return {

--- a/frontend/src/components/participation/PrticipationContents/MemberRestart/MemberRestart.tsx
+++ b/frontend/src/components/participation/PrticipationContents/MemberRestart/MemberRestart.tsx
@@ -14,7 +14,7 @@ import { requestDeleteParticipant } from '@Apis/index';
 type Props = {
   studyName: string;
   studyId: string;
-  participantId: number;
+  participantId: string;
   nickname: string;
   showMemberRegister: () => void;
 };

--- a/frontend/src/components/progress/ProgressPolling/ProgressPolling.tsx
+++ b/frontend/src/components/progress/ProgressPolling/ProgressPolling.tsx
@@ -12,19 +12,26 @@ const ProgressPolling = () => {
   const { studyId, progressStep } = useStudyInfo();
   const { updateStudyInfo } = useStudyProgressAction();
 
-  const { result } = useFetch(() => requestGetCurrentStep(studyId), {
-    refetchInterval: 3000,
-    enabled: !isHost,
-    suspense: false,
-  });
+  const { result: fetchedProgressStep } = useFetch(
+    async () => {
+      const { data } = await requestGetCurrentStep(studyId);
+
+      return data.progressStep;
+    },
+    {
+      refetchInterval: 3000,
+      enabled: !isHost,
+      suspense: false,
+    },
+  );
 
   useEffect(() => {
-    if (!result) return;
+    if (!fetchedProgressStep) return;
 
-    if (progressStep !== result.data.progressStep) {
+    if (progressStep !== fetchedProgressStep) {
       updateStudyInfo();
     }
-  }, [result]);
+  }, [fetchedProgressStep]);
 
   return null;
 };

--- a/frontend/src/components/progress/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/progress/Sidebar/Sidebar.tsx
@@ -43,7 +43,7 @@ const Sidebar = () => {
       : SIDEBAR_INFO[progressStep].paragraph;
 
   const openStudyInfo = () => {
-    openModal(<StudyInfoModal {...studyInfo} />);
+    openModal(<StudyInfoModal studyInfo={studyInfo} />);
   };
 
   return (

--- a/frontend/src/components/progress/StudyBoard/StudyBoard.tsx
+++ b/frontend/src/components/progress/StudyBoard/StudyBoard.tsx
@@ -41,7 +41,7 @@ const StudyBoard = () => {
     }
 
     if (studyStep === 'done') {
-      send({ message: '이미 끝난 스터디입니다.\n스터디의 기록 페이지로 이동합니다.' });
+      send({ message: '스터디가 종료되었습니다.\n스터디 기록 페이지로 이동합니다.' });
       navigate(`${ROUTES_PATH.record}/${studyId}`);
       return;
     }
@@ -50,7 +50,7 @@ const StudyBoard = () => {
     send({ message: STEP_NOTIFICATION_MESSAGE[progressStep] });
 
     return () => dom.updateFavicon(FAVICON_PATH.default);
-  }, [progressStep]);
+  }, [progressStep, studyStep]);
 
   return (
     <Container>

--- a/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
+++ b/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Button from '@Components/common/Button/Button';
@@ -7,6 +8,7 @@ import useFetch from '@Hooks/api/useFetch';
 
 import color from '@Styles/color';
 
+import { ROUTES_PATH } from '@Constants/routes';
 import { STEP_KEYWORDS } from '@Constants/study';
 
 import { useModal } from '@Contexts/ModalProvider';
@@ -15,7 +17,13 @@ import { requestGetMemberSubmitStatus } from '@Apis/index';
 
 import type { Step, StudyInfo } from '@Types/study';
 
-const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle, progressStep }: StudyInfo) => {
+type Props = {
+  studyInfo: StudyInfo;
+};
+
+const StudyInfoModal = ({ studyInfo }: Props) => {
+  const { studyId, name, totalCycle, timePerCycle, currentCycle, progressStep } = studyInfo;
+  const navigate = useNavigate();
   const { closeModal } = useModal();
 
   const { result: studySubmitStatus } = useFetch(
@@ -26,6 +34,13 @@ const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle,
     },
     { suspense: false, refetchInterval: 2000 },
   );
+
+  const handleExitStudy = () => {
+    if (confirm('정말로 진행 중인 스터디를 나가시겠습니까?')) {
+      navigate(ROUTES_PATH.landing);
+      closeModal();
+    }
+  };
 
   const getSubmitStatusText = (progressStep: Step, isSubmitted: boolean) => {
     if (progressStep === 'studying') return '학습 중';
@@ -39,9 +54,14 @@ const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle,
   return (
     <Layout>
       <Section>
-        <Typography variant="h5" fontWeight="700">
-          {name} 스터디
-        </Typography>
+        <TitleContainer>
+          <Typography variant="h5" fontWeight="700">
+            {name} 스터디
+          </Typography>
+          <ExitButton variant="outlined" size="x-small" onClick={handleExitStudy}>
+            스터디 나가기
+          </ExitButton>
+        </TitleContainer>
         <InfoContainer>
           <Typography variant="h6">총 사이클 횟수</Typography>
           <Typography variant="h6">{totalCycle}회</Typography>
@@ -53,11 +73,10 @@ const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle,
       </Section>
       <Separator />
       <Section>
-        <TitleContainer>
-          <Typography variant="h5" fontWeight="700">
-            스터디원 현황
-          </Typography>
-        </TitleContainer>
+        <Typography variant="h5" fontWeight="700">
+          스터디원 현황
+        </Typography>
+
         <ParticipantContainer>
           {studySubmitStatus === null ? (
             <>
@@ -117,12 +136,6 @@ const InfoContainer = styled.div`
   align-items: center;
 `;
 
-const TitleContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 20px;
-`;
-
 const ParticipantContainer = styled.div`
   height: 270px;
 
@@ -142,10 +155,29 @@ const CurrentStep = styled(Typography)`
   text-align: center;
 `;
 
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const ExitButton = styled(Button)`
+  width: fit-content;
+
+  border: none;
+
+  padding-left: 6px;
+  padding-right: 6px;
+
+  color: ${color.red[500]};
+`;
+
 const CloseButton = styled(Button)`
   width: fit-content;
-  float: right;
+  font-weight: 500;
 
+  float: right;
   margin-top: 18px;
 `;
 

--- a/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
+++ b/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
@@ -32,8 +32,6 @@ const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle,
     { suspense: false },
   );
 
-  // 리프레시 버튼
-
   const getSubmitStatusText = (progressStep: Step, isSubmitted: boolean) => {
     if (progressStep === 'studying') return '학습 중';
 

--- a/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
+++ b/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
@@ -1,7 +1,6 @@
 import { styled } from 'styled-components';
 
 import Button from '@Components/common/Button/Button';
-import RefreshButton from '@Components/common/RefreshButton/RefreshButton';
 import Typography from '@Components/common/Typography/Typography';
 
 import useFetch from '@Hooks/api/useFetch';
@@ -19,17 +18,13 @@ import type { Step, StudyInfo } from '@Types/study';
 const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle, progressStep }: StudyInfo) => {
   const { closeModal } = useModal();
 
-  const {
-    result: studySubmitStatus,
-    isLoading: refetchLoading,
-    refetch: refetchSubmitStatus,
-  } = useFetch(
+  const { result: studySubmitStatus } = useFetch(
     async () => {
       const { data } = await requestGetMemberSubmitStatus(studyId);
 
       return data.status;
     },
-    { suspense: false },
+    { suspense: false, refetchInterval: 2000 },
   );
 
   const getSubmitStatusText = (progressStep: Step, isSubmitted: boolean) => {
@@ -62,10 +57,9 @@ const StudyInfoModal = ({ studyId, name, totalCycle, timePerCycle, currentCycle,
           <Typography variant="h5" fontWeight="700">
             스터디원 현황
           </Typography>
-          <RefreshButton onClick={refetchSubmitStatus} diameter={24} />
         </TitleContainer>
         <ParticipantContainer>
-          {refetchLoading ? (
+          {studySubmitStatus === null ? (
             <>
               <InfoContainer>
                 <ParticipantSkeleton />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -18,11 +18,7 @@ export type ResponseStudies = {
   studies: StudyInfo[];
 };
 
-type ResponseParticipantInfo = {
-  participantId: number;
-  nickname: string;
-  isHost: boolean;
-};
+type ResponseParticipantInfo = Participant;
 
 export type ResponseCheckParticipants = {
   participants: ResponseParticipantInfo[] | null;


### PR DESCRIPTION
## 관련 이슈
closed #651 

## 구현 기능 및 변경 사항
- 스터디 종료시 스터디원 기록페이지로 이동하도록 수정
- 스터디원 제출 여부 조회 폴링으로 전환
- 스터디 나가기 기능 구현
  - 나가기 api 요청은 보내지 않고, 랜딩 페이지로 라우팅 해주는 로직만 넣어줬습니다.
  - 방장이 나갔을 때 api 요청을 하면 예외 사항이 엄청 많더라구요. 이 부분 너무 복잡해질 것 같아서 일단 api 요청은 해주지 않았습니다.
- participantId 타입 통일화
  - participantId가 어디서는 string이고, 어디서는 number라서 모두 string으로 바꿔줬습니다.