### PR TITLE
[BE] 이메일 기반으로 Oauth User를 찾는 로직 변경

### DIFF
--- a/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/harustudy/backend/auth/service/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
     }
 
     private Member saveOrUpdateMember(String oauthProvider, UserInfo userInfo) {
-        Member member = memberRepository.findByEmail(userInfo.email())
+        Member member = memberRepository.findByEmailAndLoginType(userInfo.email(), LoginType.from(oauthProvider))
                 .map(entity -> entity.updateUserInfo(userInfo.name(), userInfo.email(), userInfo.imageUrl()))
                 .orElseGet(() -> userInfo.toMember(LoginType.from(oauthProvider)));
         return memberRepository.save(member);

--- a/backend/src/main/java/harustudy/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/harustudy/backend/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package harustudy.backend.member.repository;
 
+import harustudy.backend.member.domain.LoginType;
 import harustudy.backend.member.domain.Member;
 import harustudy.backend.member.exception.MemberNotFoundException;
 import java.util.Optional;
@@ -12,5 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndLoginType(String email, LoginType loginType);
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed: #640 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 이메일 기반으로 멤버를 찾지 않고 이메일과 로그인 타입을 기반으로 멤버를 찾습니다.

## 스크린샷(선택)