### PR TITLE
[FE] 아이폰 사파리 접속시 화면 짤리는 문제 해결

### DIFF
--- a/frontend/src/components/progress/StudyBoard/StudyBoard.tsx
+++ b/frontend/src/components/progress/StudyBoard/StudyBoard.tsx
@@ -93,7 +93,7 @@ const Contents = styled.section`
 
   @media screen and (max-width: 768px) {
     width: 100%;
-    height: calc(100vh - 130px);
+    height: calc(var(--vh) - 130px);
 
     padding: 30px 20px;
   }

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -31,3 +31,8 @@ export const DefaultSkeletonStyle = css`
 
   animation: ${SkeletonAnimation} 5s infinite ease-in-out;
 `;
+
+// IOS vh 글로벌 css 변수 설정
+document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`);
+
+window.addEventListener('resize', () => document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`));


### PR DESCRIPTION
## 관련 이슈
close #645 

## 구현 기능 및 변경 사항
- 실제 innerHeight를 측정한 글로벌 css 변수(--vh) 추가
- 진행페이지에 적용

## 스크린샷(선택)

### 수정 전

<img width="300px" src="https://github.com/woowacourse-teams/2023-haru-study/assets/73513965/371c05d3-659d-40cd-bc8f-56f947d2448b" />

하단 버튼이 사파리 주소창에 짤리고 스크롤이 생긴다

### 수정 후
<img width="300px" src="https://github.com/woowacourse-teams/2023-haru-study/assets/73513965/fcb2f27a-40b1-4c70-ba85-10bb7cc5d7f0" />

하단 버튼이 잘 보인다