### PR TITLE
[FE] Modal Confirm 컴포넌트 구현

### DIFF
--- a/frontend/src/components/common/Modal/Template/Alert.tsx
+++ b/frontend/src/components/common/Modal/Template/Alert.tsx
@@ -1,4 +1,4 @@
-import { css, styled } from 'styled-components';
+import { styled } from 'styled-components';
 
 import Button from '@Components/common/Button/Button';
 import Typography from '@Components/common/Typography/Typography';
@@ -20,25 +20,9 @@ const Alert = ({ message, closeModal, onClose }: Props) => {
   return (
     <Layout>
       <Typography variant="p3">{message}</Typography>
-      <Button
-        variant="outlined"
-        $style={css`
-          color: ${color.blue[500]};
-
-          border: none;
-
-          &:hover {
-            &:enabled {
-              background-color: ${color.blue[50]};
-            }
-          }
-        `}
-        size="x-small"
-        $block={false}
-        onClick={handleClose}
-      >
+      <CloseButton variant="outlined" size="x-small" $block={false} onClick={handleClose}>
         확인
-      </Button>
+      </CloseButton>
     </Layout>
   );
 };
@@ -49,8 +33,16 @@ const Layout = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+`;
 
-  button {
-    align-self: flex-end;
+const CloseButton = styled(Button)`
+  width: fit-content;
+  align-self: flex-end;
+
+  color: ${color.blue[500]};
+  border: none;
+
+  &:hover:enabled {
+    background-color: ${color.blue[50]};
   }
 `;

--- a/frontend/src/components/common/Modal/Template/Confirm.tsx
+++ b/frontend/src/components/common/Modal/Template/Confirm.tsx
@@ -1,0 +1,72 @@
+import { styled } from 'styled-components';
+
+import Button from '@Components/common/Button/Button';
+import Typography from '@Components/common/Typography/Typography';
+
+import color from '@Styles/color';
+
+type Props = {
+  message: string;
+  closeModal: () => void;
+  onConfirm: () => void;
+  onCancel?: () => void;
+};
+
+const Confirm = ({ message, closeModal, onConfirm, onCancel }: Props) => {
+  const handleConfirm = () => {
+    closeModal();
+    onConfirm();
+  };
+
+  const handleCancel = () => {
+    closeModal();
+    onCancel?.();
+  };
+
+  return (
+    <Layout>
+      <Typography variant="p3">{message}</Typography>
+      <ButtonContainer>
+        <ConfirmButton variant="outlined" size="x-small" $block={false} onClick={handleConfirm}>
+          확인
+        </ConfirmButton>
+        <CancelButton variant="outlined" size="x-small" onClick={handleCancel}>
+          취소
+        </CancelButton>
+      </ButtonContainer>
+    </Layout>
+  );
+};
+
+export default Confirm;
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: end;
+  gap: 4px;
+`;
+
+const ConfirmButton = styled(Button)`
+  width: fit-content;
+
+  border: none;
+  color: ${color.blue[500]};
+
+  &:hover:enabled {
+    background-color: ${color.blue[50]};
+  }
+`;
+
+const CancelButton = styled(Button)`
+  width: fit-content;
+
+  color: ${color.neutral[500]};
+
+  border: none;
+`;

--- a/frontend/src/components/common/Typography/Typography.tsx
+++ b/frontend/src/components/common/Typography/Typography.tsx
@@ -68,6 +68,8 @@ const Typography = ({ variant, fontSize, fontWeight, color, $style, children, ..
 };
 
 const StyledTypography = styled.div<Props>`
+  white-space: pre-line;
+
   ${({ variant, fontSize, fontWeight, color, $style }) => css`
     font-size: ${fontSize || FONT_STYLE.fontSize[variant]};
     font-weight: ${fontWeight || FONT_STYLE.fontWeight[variant]};

--- a/frontend/src/components/lobby/StudyLobbyContents/StudyLobbyContents.tsx
+++ b/frontend/src/components/lobby/StudyLobbyContents/StudyLobbyContents.tsx
@@ -1,8 +1,10 @@
-import { unstable_useBlocker, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Button from '@Components/common/Button/Button';
 import ParticipantCodeCopier from '@Components/lobby/ParticipantCodeCopier/ParticipantCodeCopier';
+
+import useConfirmBeforeRouting from '@Hooks/common/useRouteBlocker';
 
 import { ROUTES_PATH } from '@Constants/routes';
 
@@ -28,6 +30,7 @@ const StudyLobbyContents = () => {
 
   const navigateToHome = () => {
     navigate(ROUTES_PATH.landing);
+    console.log(132);
   };
 
   const handleStartStudy = async () => {
@@ -37,22 +40,12 @@ const StudyLobbyContents = () => {
     navigate(`${ROUTES_PATH.progress}/${studyId}`, { state: { block: false } });
   };
 
-  unstable_useBlocker(({ nextLocation }) => {
-    const state = nextLocation.state as { block: boolean } | null;
-    if (state?.block === false) return false;
-
-    if (confirm('정말로 스터디를 나가시겠습니까?')) {
-      exitStudy();
-      return false;
-    }
-
-    return true;
-  });
+  useConfirmBeforeRouting('정말로 스터디를 나가시겠습니까?', exitStudy);
 
   return (
     participantCode && (
       <Layout>
-        <ParticipantCodeCopier participantCode={participantCode}></ParticipantCodeCopier>
+        <ParticipantCodeCopier participantCode={participantCode} />
         <ParticipantList studyId={studyId} />
         <BottomButtonWrapper>
           {isHost ? (

--- a/frontend/src/components/progress/PlanningForm/PlanningForm.tsx
+++ b/frontend/src/components/progress/PlanningForm/PlanningForm.tsx
@@ -22,7 +22,7 @@ import usePlanningForm from '../hooks/usePlanningForm';
 
 const PlanningForm = () => {
   const { isShow: isOpenOptionalQuestion, toggleShow: toggleOptionalQuestion } = useDisplay();
-  const { openModal } = useModal();
+  const { openModal, openConfirm } = useModal();
   const { send } = useNotification();
 
   const { isHost } = useParticipantInfo();
@@ -45,13 +45,15 @@ const PlanningForm = () => {
   const moveToStudyingStep = async () => {
     const isAllParticipantSubmitted = await checkAllParticipantSubmitted();
 
-    if (
-      !isAllParticipantSubmitted &&
-      !confirm('아직 목표 제출을 하지 않은 스터디원이 있습니다. 그래도 학습 단계로 넘어가시겠습니까?')
-    )
+    if (!isAllParticipantSubmitted) {
+      openConfirm(
+        '아직 목표 제출을 하지 않은 스터디원이 있습니다.\n그래도 학습 단계로 넘어가시겠습니까?',
+        moveToNextStep,
+      );
       return;
+    }
 
-    await moveToNextStep();
+    moveToNextStep();
   };
 
   return (

--- a/frontend/src/components/progress/RetrospectForm/RetrospectForm.tsx
+++ b/frontend/src/components/progress/RetrospectForm/RetrospectForm.tsx
@@ -12,6 +12,7 @@ import color from '@Styles/color';
 import { ROUTES_PATH } from '@Constants/routes';
 import { RETROSPECT_QUESTIONS } from '@Constants/study';
 
+import { useModal } from '@Contexts/ModalProvider';
 import { useNotification } from '@Contexts/NotificationProvider';
 import { useParticipantInfo, useStudyInfo, useStudyProgressAction } from '@Contexts/StudyProgressProvider';
 
@@ -22,6 +23,7 @@ import useRetrospectForm from '../hooks/useRetrospectForm';
 
 const RetrospectForm = () => {
   const navigate = useNavigate();
+  const { openConfirm } = useModal();
   const { isShow: isOpenOptionalQuestion, toggleShow: toggleOptionalQuestion } = useDisplay();
   const { send } = useNotification();
 
@@ -41,13 +43,20 @@ const RetrospectForm = () => {
 
   const moveToNextCycle = async () => {
     const isAllParticipantSubmitted = await checkAllParticipantSubmitted();
+
+    const onNext = async () => {
+      await moveToNextStep();
+      if (isLastCycle) navigate(`${ROUTES_PATH.record}/${studyId}`);
+    };
+
     const notiMessage = isLastCycle ? '그래도 스터디를 종료하시겠습니까?' : '그래도 다음 사이클로 넘어가시겠습니까?';
 
-    if (!isAllParticipantSubmitted && !confirm(`아직 제출을 하지 않은 스터디원이 있습니다. ${notiMessage}`)) return;
+    if (!isAllParticipantSubmitted) {
+      openConfirm(`아직 제출을 하지 않은 스터디원이 있습니다.\n${notiMessage}`, onNext);
+      return;
+    }
 
-    await moveToNextStep();
-
-    if (isLastCycle) navigate(`${ROUTES_PATH.record}/${studyId}`);
+    onNext();
   };
 
   return (

--- a/frontend/src/components/progress/StudyBoard/StudyBoard.tsx
+++ b/frontend/src/components/progress/StudyBoard/StudyBoard.tsx
@@ -93,7 +93,7 @@ const Contents = styled.section`
 
   @media screen and (max-width: 768px) {
     width: 100%;
-    height: calc(100vh - 130px);
+    height: calc(var(--vh) - 130px);
 
     padding: 30px 20px;
   }

--- a/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
+++ b/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
@@ -23,8 +23,9 @@ type Props = {
 
 const StudyInfoModal = ({ studyInfo }: Props) => {
   const { studyId, name, totalCycle, timePerCycle, currentCycle, progressStep } = studyInfo;
+
   const navigate = useNavigate();
-  const { closeModal } = useModal();
+  const { openConfirm, closeModal } = useModal();
 
   const { result: studySubmitStatus } = useFetch(
     async () => {
@@ -36,10 +37,11 @@ const StudyInfoModal = ({ studyInfo }: Props) => {
   );
 
   const handleExitStudy = () => {
-    if (confirm('정말로 진행 중인 스터디를 나가시겠습니까?')) {
+    closeModal();
+    openConfirm('정말로 진행 중인 스터디를 나가시겠습니까?', () => {
       navigate(ROUTES_PATH.landing);
       closeModal();
-    }
+    });
   };
 
   const getSubmitStatusText = (progressStep: Step, isSubmitted: boolean) => {

--- a/frontend/src/contexts/ModalProvider.tsx
+++ b/frontend/src/contexts/ModalProvider.tsx
@@ -3,11 +3,13 @@ import { createContext, useCallback, useContext, useState } from 'react';
 
 import Modal from '@Components/common/Modal/Modal';
 import Alert from '@Components/common/Modal/Template/Alert';
+import Confirm from '@Components/common/Modal/Template/Confirm';
 
 export type ModalContextType = {
   isOpen: boolean;
   openModal: (modalContents: ReactNode) => void;
   openAlert: (message: string, onClose?: () => void) => void;
+  openConfirm: (message: string, onConfirm: () => void, onCancel?: () => void) => void;
   closeModal: () => void;
 };
 
@@ -28,10 +30,17 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
     [closeModal],
   );
 
+  const openConfirm = useCallback(
+    (message: string, onConfirm: () => void, onCancel?: () => void) =>
+      setModalContents(<Confirm message={message} closeModal={closeModal} onConfirm={onConfirm} onCancel={onCancel} />),
+    [closeModal],
+  );
+
   const value = {
     isOpen,
     openModal,
     openAlert,
+    openConfirm,
     closeModal,
   };
 

--- a/frontend/src/hooks/common/useRouteBlocker.ts
+++ b/frontend/src/hooks/common/useRouteBlocker.ts
@@ -1,0 +1,22 @@
+import { unstable_useBlocker, useNavigate } from 'react-router-dom';
+
+import { useModal } from '@Contexts/ModalProvider';
+
+const useConfirmBeforeRouting = (message: string, onConfirm?: () => void) => {
+  const navigate = useNavigate();
+  const { openConfirm } = useModal();
+
+  unstable_useBlocker(({ nextLocation }) => {
+    const state = nextLocation.state as { block: boolean } | null;
+    if (state?.block === false) return false;
+
+    openConfirm(message, () => {
+      onConfirm?.();
+      navigate(nextLocation, { state: { block: false } });
+    });
+
+    return true;
+  });
+};
+
+export default useConfirmBeforeRouting;

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -31,3 +31,8 @@ export const DefaultSkeletonStyle = css`
 
   animation: ${SkeletonAnimation} 5s infinite ease-in-out;
 `;
+
+// IOS vh 글로벌 css 변수 설정
+document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`);
+
+window.addEventListener('resize', () => document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`));


### PR DESCRIPTION
## 관련 이슈
close #650 

## 구현 기능 및 변경 사항
- Confirm Modal 컴포넌트 구현
  - useModal의 openConfirm 함수를 사용하여 사용하면 됩니다.(openAlert과 동일하게 사용)
  - 브라우저의 기본 confirm을 사용하는 로직을 해당 컴포넌트로 대체하도록 했습니다.
- useConfirmBeforeRouting 훅 구현
  - 라우팅을 하기 전, Confirm 모달을 띄워서 정말로 라우팅을 할건지 물어보는 기능을 수행하는 훅입니다
## 스크린샷(선택)

![스크린샷 2023-10-18 오후 7 35 40](https://github.com/woowacourse-teams/2023-haru-study/assets/73513965/375ca5c9-5d24-482d-8fa6-5f745b5f7e55)
![스크린샷 2023-10-18 오후 7 36 11](https://github.com/woowacourse-teams/2023-haru-study/assets/73513965/6aaf2956-b593-44bf-b5df-4099567852ee)
