### PR TITLE
[FE] StudyInfoModal 컴포넌트 errorBoundary 속성 false로 설정

### DIFF
--- a/frontend/src/components/lobby/StudyLobbyContents/StudyLobbyContents.tsx
+++ b/frontend/src/components/lobby/StudyLobbyContents/StudyLobbyContents.tsx
@@ -30,7 +30,6 @@ const StudyLobbyContents = () => {
 
   const navigateToHome = () => {
     navigate(ROUTES_PATH.landing);
-    console.log(132);
   };
 
   const handleStartStudy = async () => {

--- a/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
+++ b/frontend/src/components/progress/StudyInfoModal/StudyInfoModal.tsx
@@ -33,7 +33,7 @@ const StudyInfoModal = ({ studyInfo }: Props) => {
 
       return data.status;
     },
-    { suspense: false, refetchInterval: 2000 },
+    { suspense: false, refetchInterval: 2000, errorBoundary: false },
   );
 
   const handleExitStudy = () => {


### PR DESCRIPTION
## 버그 사항
- dev 서버에서 확인해보니 아직 모달 킨 상태로 스터디가 종료되었을 때 404로 넘어가는 버그가 완전히 해결되지 않아서 다시 수정 후 PR 보냅니다.

- 모달에서는 DOM 위치 때문에 에러 발생시 글로벌 에러바운더리가 적용이 안되고, 곧바로 에러페이지가 떠요.
- 그래서 StudyInfoModal에서 useFetch의 errorBoundary 옵션을 false로 설정해줬습니다.
- 추가로 의미없는 console.log 제거해줬어용