### PR TITLE
[BE] CI에서 사용하지 않는 workflow_dispatch 내용 제거 #722

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
     types: [ opened, synchronize, reopened ]
-  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
close #722
## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
workflow_dispatch는 수동으로 지정한 워크플로우를 돌리는 기능인데,
구문만 들어가있고 어떤 동작은 할 지 명시가 안 되어있어서 아예 불필요한 구문인 것 같아요
자잘하긴 한데 본 김에 없애면 어떨까 해서 올립니다

어떤 기능인지 참고하시라고 링크 올려용
https://glebbahmutov.com/blog/run-and-trigger-github-workflow/
