### PR TITLE
[FE] cd용 github action workflow 추가

### DIFF
--- a/.github/workflows/frontend-develop-deploy.yml
+++ b/.github/workflows/frontend-develop-deploy.yml
@@ -1,0 +1,47 @@
+name: frontend-build-test
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: ./frontend
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Test & Build
+        run: yarn build
+
+      - name: SCP
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOST_WS }}
+          key: ${{ secrets.PRIVATE_KEY_WS }}
+          source: "./dist/*"
+          target: "/home/ubuntu/frontend-develop"
+          strip_components: 1
+
+      - name: action-slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Github Action # default: 8398a7@action-slack
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()

--- a/.github/workflows/frontend-develop-deploy.yml
+++ b/.github/workflows/frontend-develop-deploy.yml
@@ -26,14 +26,27 @@ jobs:
       - name: Test & Build
         run: yarn build
 
-      - name: SCP
+      - name: Story book build
+        run: yarn build-storybook
+
+      - name: Scp html
         uses: appleboy/scp-action@master
         with:
           username: ubuntu
           host: ${{ secrets.HOST_WS }}
           key: ${{ secrets.PRIVATE_KEY_WS }}
           source: "./dist/*"
-          target: "/home/ubuntu/frontend-develop"
+          target: "/home/ubuntu/frontend-develop/html"
+          strip_components: 1
+
+      - name: Scp story book
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOST_WS }}
+          key: ${{ secrets.PRIVATE_KEY_WS }}
+          source: "./storybook-static/*"
+          target: "/home/ubuntu/frontend-develop/storybook"
           strip_components: 1
 
       - name: action-slack

--- a/.github/workflows/frontend-main-deploy.yml
+++ b/.github/workflows/frontend-main-deploy.yml
@@ -1,0 +1,47 @@
+name: frontend-build-test
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: ./frontend
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Test & Build
+        run: yarn build
+
+      - name: SCP
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOST_WS }}
+          key: ${{ secrets.PRIVATE_KEY_WS }}
+          source: "./dist/*"
+          target: "/home/ubuntu/frontend-production"
+          strip_components: 1
+
+      - name: action-slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Github Action # default: 8398a7@action-slack
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()

--- a/.github/workflows/frontend-main-deploy.yml
+++ b/.github/workflows/frontend-main-deploy.yml
@@ -26,14 +26,27 @@ jobs:
       - name: Test & Build
         run: yarn build
 
-      - name: SCP
+      - name: Story book build
+        run: yarn build-storybook
+
+      - name: Scp html
         uses: appleboy/scp-action@master
         with:
           username: ubuntu
           host: ${{ secrets.HOST_WS }}
           key: ${{ secrets.PRIVATE_KEY_WS }}
           source: "./dist/*"
-          target: "/home/ubuntu/frontend-production"
+          target: "/home/ubuntu/frontend-production/html"
+          strip_components: 1
+
+      - name: Scp story book
+        uses: appleboy/scp-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.HOST_WS }}
+          key: ${{ secrets.PRIVATE_KEY_WS }}
+          source: "./storybook-static/*"
+          target: "/home/ubuntu/frontend-production/storybook"
           strip_components: 1
 
       - name: action-slack


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed: #739 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 프론트 cd용 파일 2개 만들었습니다.
- 기존에 존재하던 workflow는 ci 테스트용이고 이번에 추가된 것은 직접 빌드 눌러서 수동으로 cd 돌리도록 만들었습니다.
- **주의사항** : 수동으로 배포시 브랜치를 선택해야 하는데 이 때 잘 골라야 합니다.

## 스크린샷(선택)