### PR TITLE
[BE] 같은 스터디 진행 이후 다른 멤버 스터디 기록이 조회되지 않는 오류 수정

### DIFF
--- a/backend/src/main/java/harustudy/backend/content/service/ContentService.java
+++ b/backend/src/main/java/harustudy/backend/content/service/ContentService.java
@@ -45,23 +45,22 @@ public class ContentService {
         return getContentsResponseByCycleFilter(cycle, participant);
     }
 
-    private static Participant findParticipantById(List<Participant> participants, Long participantId) {
+    private void validateMemberIncludedIn(List<Participant> participants, Member member) {
+        if (isMemberIncludedInParticipants(member, participants)) {
+            throw new AuthorizationException();
+        }
+    }
+
+    private boolean isMemberIncludedInParticipants(Member member, List<Participant> participants) {
+        return participants.stream()
+                .noneMatch(participant -> participant.isCreatedBy(member));
+    }
+
+    private Participant findParticipantById(List<Participant> participants, Long participantId) {
         return participants.stream()
                 .filter(participant -> participant.isSameId(participantId))
                 .findFirst()
                 .orElseThrow(ParticipantNotFoundException::new);
-    }
-
-    private List<Participant> validateMemberIncludedIn(List<Participant> participants, Member member) {
-        if (isMemberIncludedInParticipants(member, participants)) {
-            throw new AuthorizationException();
-        }
-        return participants;
-    }
-
-    private static boolean isMemberIncludedInParticipants(Member member, List<Participant> participants) {
-        return participants.stream()
-                .noneMatch(participant -> participant.isCreatedBy(member));
     }
 
     private ContentsResponse getContentsResponseByCycleFilter(Integer cycle, Participant participant) {

--- a/backend/src/main/java/harustudy/backend/content/service/ContentService.java
+++ b/backend/src/main/java/harustudy/backend/content/service/ContentService.java
@@ -46,12 +46,12 @@ public class ContentService {
     }
 
     private void validateMemberIncludedIn(List<Participant> participants, Member member) {
-        if (isMemberIncludedInParticipants(member, participants)) {
+        if (isMemberNotIncludedInParticipants(member, participants)) {
             throw new AuthorizationException();
         }
     }
 
-    private boolean isMemberIncludedInParticipants(Member member, List<Participant> participants) {
+    private boolean isMemberNotIncludedInParticipants(Member member, List<Participant> participants) {
         return participants.stream()
                 .noneMatch(participant -> participant.isCreatedBy(member));
     }

--- a/backend/src/main/java/harustudy/backend/participant/domain/Participant.java
+++ b/backend/src/main/java/harustudy/backend/participant/domain/Participant.java
@@ -76,20 +76,20 @@ public class Participant extends BaseTimeEntity {
         }
     }
 
+    public boolean isSameId(Long id) {
+        return this.id.equals(id);
+    }
+
     public boolean isParticipantOf(Study study) {
         return this.study.getId().equals(study.getId());
     }
 
-    public boolean isNotCreatedBy(Member member) {
-        return !this.member.getId().equals(member.getId());
+    public boolean isCreatedBy(Member member) {
+        return this.member.getId().equals(member.getId());
     }
 
     public boolean hasSameNicknameWith(Participant participant) {
         return this.nickname.equals(participant.nickname);
-    }
-
-    public boolean isNotIncludedIn(Study other) {
-        return !study.getId().equals(other.getId());
     }
 
     public void validateIsHost() {
@@ -105,7 +105,7 @@ public class Participant extends BaseTimeEntity {
     }
 
     public void validateIsCreatedByMember(Member member) {
-        if (isNotCreatedBy(member)) {
+        if (!isCreatedBy(member)) {
             throw new AuthorizationException();
         }
     }

--- a/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
+++ b/backend/src/test/java/harustudy/backend/content/service/ContentServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import harustudy.backend.auth.dto.AuthMember;
+import harustudy.backend.auth.exception.AuthorizationException;
 import harustudy.backend.content.domain.Content;
 import harustudy.backend.content.dto.ContentResponse;
 import harustudy.backend.content.dto.ContentsResponse;
@@ -45,6 +46,7 @@ class ContentServiceTest {
 
     private Study study;
     private Member member;
+    private Member member2;
     private Participant participant;
     private Content content;
 
@@ -52,12 +54,13 @@ class ContentServiceTest {
     void setUp() {
         study = new Study("studyName", 1, 20);
         member = new Member("nickname", "email", "imageUrl", LoginType.GUEST);
+        member2 = new Member("nickname2", "email2", "imageUrl2", LoginType.GUEST);
         participant = Participant.createParticipantOfStudy(study, member, "nickname");
-
         content = new Content(participant, 1);
 
         entityManager.persist(study);
         entityManager.persist(member);
+        entityManager.persist(member2);
         entityManager.persist(participant);
         entityManager.persist(content);
 
@@ -225,6 +228,26 @@ class ContentServiceTest {
     }
 
     @Test
+    void 스터디원은_같은_스터디_내_다른_멤버의_콘텐츠를_조회할_수_있다() {
+        // given
+        AuthMember authMember = new AuthMember(member.getId());
+        Participant participant2 = Participant.createParticipantOfStudy(study, member2, "nickname2");
+        Content contentOfMember2 = new Content(participant2, 1);
+
+        entityManager.persist(participant2);
+        entityManager.persist(contentOfMember2);
+
+        EntityManagerUtil.flushAndClearContext(entityManager);
+
+        // when
+        ContentsResponse contentsWithFilter = contentService.findContentsWithFilter(authMember,
+                study.getId(), participant2.getId(), null);
+
+        // then
+        assertThat(contentsWithFilter.content().size()).isEqualTo(1);
+    }
+
+    @Test
     void 스터디에_참여한_특정_스터디원의_콘텐츠를_조회시_스터디가_없으면_예외를_던진다() {
         // given
         AuthMember authMember = new AuthMember(member.getId());
@@ -246,5 +269,15 @@ class ContentServiceTest {
                 () -> contentService.findContentsWithFilter(authMember,
                         study.getId(), 999L, null))
                 .isInstanceOf(ParticipantNotFoundException.class);
+    }
+
+    @Test
+    void 같은_스터디에_참여하지_않은_멤버가_다른_스터디_멤버의_콘텐츠를_조회하면_예외를_던진다() {
+        // given
+        AuthMember authMember = new AuthMember(member2.getId());
+
+        // when, then
+        assertThatThrownBy(() -> contentService.findContentsWithFilter(authMember,
+                study.getId(), participant.getId(), null)).isInstanceOf(AuthorizationException.class);
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #757 

## 구현 기능 및 변경 사항
<!-- 구현한 내용에 대해 설명해주세요 -->
- 같은 스터디 참여 인원 간에는 서로 스터디 기록 조회가 가능해야 하는데 과거 리팩토링 PR에서 검증 부분이 잘못 수정된 부분이 있었습니다. 이를 수정했습니다. 
- 스터디에 참여하지 않은 인원이 스터디 참여 인원의 기록을 조회하려고 하면 권한 오류가 발생하도록 했습니다.
- 같은 실수가 반복되지 않도록 스터디 기록 조회 관련 service 테스트를 추가했습니다.
